### PR TITLE
회원가입 API (POST /api/users/signup)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,7 +10,12 @@ export default defineConfig([
   {
     rules: {
       semi: "error",
-      indent: ["error", 2]
+      indent: ["error", 2,
+        {
+          SwitchCase: 1,
+          ignoredNodes: ["PropertyDefinition[decorators]"]
+        }
+      ]
     }
   },
   { files: ["**/*.{js,mjs,cjs,ts,mts,cts}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: globals.node } },

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-    preset: "ts-jest",
-    testEnvironment: "node",
-    testMatch: ["**/tests/*.test.ts"]
+  preset: "ts-jest",
+  testEnvironment: "node",
+  testMatch: ["**/tests/**/*.test.ts"]
 };

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "cross-env NODE_ENV=test jest",
+    "test:unit": "cross-env NODE_ENV=test jest src/tests/unit",
+    "test:integration": "cross-env NODE_ENV=test jest src/tests/integration",
     "start": "cross-env NODE_ENV=development nodemon src/index.ts",
     "dev": "cross-env NODE_ENV=development nodemon --watch src --exec ts-node src/index.ts",
     "lint": "eslint . --ext .ts",

--- a/src/app.ts
+++ b/src/app.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import { RequestContext } from '@mikro-orm/postgresql';
 
 import { DI } from './index';
+import { userRouter } from './routes/userRoutes';
 
 const app = express();
 app.use(express.json());
@@ -9,5 +10,7 @@ app.use(express.json());
 app.use((req, res, next) => {
   RequestContext.create(DI.orm.em, next);
 });
+
+app.use('/api/users', userRouter);
 
 export default app;

--- a/src/constants/error-messages.ts
+++ b/src/constants/error-messages.ts
@@ -12,4 +12,8 @@ export const ErrorMessages = {
     
   INVALID_EMAIL: '올바른 이메일 형식이 아닙니다.',
   INVALID_PHONE: '올바른 휴대폰 번호 형식이 아닙니다.',
+
+  EXISTING_USERNAME: '중복된 아이디입니다.',
+  EXISTING_EMAIL: '중복된 이메일입니다.',
+  EXISTING_PHONE: '중복된 휴대폰 번호입니다.'
 };

--- a/src/constants/error-messages.ts
+++ b/src/constants/error-messages.ts
@@ -1,0 +1,15 @@
+export const ErrorMessages = {
+  VALIDATION_FAILED: '유효성 검사 실패',
+
+  REQUIRED: '필수 입력 항목입니다.',
+
+  STRING: '문자열 형식이어야 합니다.',
+  BOOLEAN: '불린 형식이어야 합니다.',
+
+  USERNAME_LENGTH: '아이디는 8자 이하여야 합니다.',
+  NAME_LENGTH: '이름은 8자 이하여야 합니다.',
+  PASSWORD_LENGTH: '비밀번호는 15자 이하여야 합니다.',
+    
+  INVALID_EMAIL: '올바른 이메일 형식이 아닙니다.',
+  INVALID_PHONE: '올바른 휴대폰 번호 형식이 아닙니다.',
+};

--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -8,8 +8,8 @@ export const signup = async (req: Request, res: Response) => {
     const em = RequestContext.getEntityManager() as EntityManager;
     const user = await createUser(em, req.body);
 
-    const { password, ...safeUser } = user;
-    res.status(201).json(safeUser);
+    const { password, ...newUser } = user;
+    res.status(201).json(newUser);
   }
   catch (err: any) {
     res.status(400).json({ message: err.message });

--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -1,0 +1,17 @@
+import { Request, Response } from 'express';
+
+import { createUser } from '../services/userService';
+import { EntityManager, RequestContext } from '@mikro-orm/postgresql';
+
+export const signup = async (req: Request, res: Response) => {
+  try {
+    const em = RequestContext.getEntityManager() as EntityManager;
+    const user = await createUser(em, req.body);
+
+    const { password, ...safeUser } = user;
+    res.status(201).json(safeUser);
+  }
+  catch (err: any) {
+    res.status(400).json({ message: err.message });
+  }
+};

--- a/src/dtos/CreateUserDto.ts
+++ b/src/dtos/CreateUserDto.ts
@@ -1,0 +1,32 @@
+import { IsEmail, IsOptional, IsString, IsBoolean, Length, Matches, IsNotEmpty } from 'class-validator';
+
+import { ErrorMessages } from '../constants/error-messages';
+
+export class CreateUserDto {
+  @Length(1, 8, { message: ErrorMessages.USERNAME_LENGTH })
+  @IsString({ message: ErrorMessages.STRING })
+  @IsNotEmpty({ message: ErrorMessages.REQUIRED })
+  username: string;
+
+  @Length(1, 8, { message: ErrorMessages.NAME_LENGTH })
+  @IsString({ message: ErrorMessages.STRING })
+  @IsNotEmpty({ message: ErrorMessages.REQUIRED })
+  name: string;
+
+  @Length(1, 15, { message: ErrorMessages.PASSWORD_LENGTH })
+  @IsString({ message: ErrorMessages.STRING })
+  @IsNotEmpty({ message: ErrorMessages.REQUIRED })
+  password: string;
+
+  @IsEmail({}, { message: ErrorMessages.INVALID_EMAIL })
+  @IsNotEmpty({ message: ErrorMessages.REQUIRED })
+  email: string;
+
+  @IsOptional()
+  @Matches(/^010-\d{4}-\d{4}$/, { message: ErrorMessages.INVALID_PHONE })
+  phone?: string;
+
+  @IsOptional()
+  @IsBoolean({ message: ErrorMessages.BOOLEAN })
+  isAdmin?: boolean;
+}

--- a/src/entities/BaseEntity.ts
+++ b/src/entities/BaseEntity.ts
@@ -1,0 +1,13 @@
+import { Entity, PrimaryKey, Property } from '@mikro-orm/postgresql';
+
+@Entity()
+export abstract class BaseEntity {
+  @PrimaryKey()
+  id!: number;
+
+  @Property()
+  createdAt = new Date();
+
+  @Property({ onUpdate: () => new Date() })
+  updatedAt = new Date();
+}

--- a/src/entities/User.ts
+++ b/src/entities/User.ts
@@ -1,0 +1,24 @@
+import { Entity, Property } from '@mikro-orm/postgresql';
+
+import { BaseEntity } from './BaseEntity';
+
+@Entity()
+export class User extends BaseEntity{
+  @Property({ unique: true, length: 8 })
+  username!: string;
+
+  @Property({ length: 255 })
+  password!: string;
+
+  @Property({ length: 8 })
+  name!: string;
+
+  @Property({ unique: true, length: 255 })
+  email!: string;
+
+  @Property({ unique: true, nullable: true, length: 20 })
+  phone?: string;
+
+  @Property()
+  isAdmin: boolean = false;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,12 +10,10 @@ export const DI = {} as {
   em: EntityManager;
 };
 
-const start = async () => {
+export const start = (async () => {
   const orm = await MikroORM.init(config);
   DI.orm = orm;
   DI.em = DI.orm.em;
 
-  app.listen(3000, () => console.log('Server running'));
-};
-
-start();
+  DI.server = app.listen(3000, () => console.log('Server running'));
+})();

--- a/src/middlewares/validate.ts
+++ b/src/middlewares/validate.ts
@@ -1,0 +1,25 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { Request, Response, NextFunction } from 'express';
+
+import { ErrorMessages } from '../constants/error-messages';
+
+export const validateDto = (dtoClass: any) => {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    const instance = plainToInstance(dtoClass, req.body);
+    const errors = await validate(instance);
+
+    if (errors.length > 0) {
+      return res.status(400).json({
+        message: ErrorMessages.VALIDATION_FAILED,
+        errors: errors.map((e) => ({
+          field: e.property,
+          constraints: e.constraints,
+        }))
+      });
+    }
+
+    req.body = instance;
+    next();
+  };
+};

--- a/src/mikro-orm.config.ts
+++ b/src/mikro-orm.config.ts
@@ -3,11 +3,13 @@ import { TsMorphMetadataProvider } from '@mikro-orm/reflection';
 import dotenv from 'dotenv';
 import path from 'path';
 
+import { User } from './entities/User';
+
 const envFile = `.env.${process.env.NODE_ENV || 'development'}`;
 dotenv.config({ path: path.resolve(__dirname, '..', envFile) });
 
 const config: Options = {
-  entities: [],
+  entities: [User],
   dbName: process.env.dbName,
   driver: PostgreSqlDriver,
   user: process.env.user,

--- a/src/routes/userRoutes.ts
+++ b/src/routes/userRoutes.ts
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+
+import { signup } from '../controllers/userController';
+
+const router = Router();
+
+router.post('/signup', signup);
+
+export const userRouter = router;

--- a/src/routes/userRoutes.ts
+++ b/src/routes/userRoutes.ts
@@ -1,9 +1,11 @@
 import { Router } from 'express';
 
 import { signup } from '../controllers/userController';
+import { validateDto } from '../middlewares/validate';
+import { CreateUserDto } from '../dtos/CreateUserDto';
 
 const router = Router();
 
-router.post('/signup', signup);
+router.post('/signup', validateDto(CreateUserDto), signup);
 
 export const userRouter = router;

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -1,10 +1,15 @@
-import { EntityManager } from '@mikro-orm/core';
+import { EntityManager, EntityRepository } from '@mikro-orm/core';
 import bcrypt from 'bcrypt';
 
 import { User } from '../entities/User';
 import { CreateUserDto } from '../dtos/CreateUserDto';
+import { ErrorMessages } from '../constants/error-messages';
 
 export async function createUser(em: EntityManager, data: CreateUserDto) {
+  const repo = em.getRepository(User);
+
+  await checkUserCreateData(repo, data.username, data.email, data.phone);
+
   const user = new User();
   user.username = data.username;
   user.password = await bcrypt.hash(data.password, 10);
@@ -13,10 +18,25 @@ export async function createUser(em: EntityManager, data: CreateUserDto) {
   user.phone = data.phone;
   user.isAdmin = data.isAdmin ?? false;
 
-  const userRepo = em.getRepository(User);
-  userRepo.create(user);
+  repo.create(user);
     
   await em.flush();
 
   return user;
+}
+
+async function checkUserCreateData(repo: EntityRepository<User>, username: string, email: string, phone?: string) {
+  const existingUser = await repo.findOne({
+    $or: [
+      { username: username },
+      { email: email },
+      ...(phone ? [{ phone: phone }] : [])
+    ]}
+  );
+
+  if (existingUser) {
+    if (existingUser.username === username) throw new Error(ErrorMessages.EXISTING_USERNAME);
+    if (existingUser.email === email) throw new Error(ErrorMessages.EXISTING_EMAIL);
+    if (phone && existingUser.phone === phone) throw new Error(ErrorMessages.EXISTING_PHONE);
+  }
 }

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -2,8 +2,9 @@ import { EntityManager } from '@mikro-orm/core';
 import bcrypt from 'bcrypt';
 
 import { User } from '../entities/User';
+import { CreateUserDto } from '../dtos/CreateUserDto';
 
-export async function createUser(em: EntityManager, data: any) {
+export async function createUser(em: EntityManager, data: CreateUserDto) {
   const user = new User();
   user.username = data.username;
   user.password = await bcrypt.hash(data.password, 10);

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -1,0 +1,21 @@
+import { EntityManager } from '@mikro-orm/core';
+import bcrypt from 'bcrypt';
+
+import { User } from '../entities/User';
+
+export async function createUser(em: EntityManager, data: any) {
+  const user = new User();
+  user.username = data.username;
+  user.password = await bcrypt.hash(data.password, 10);
+  user.name = data.name;
+  user.email = data.email;
+  user.phone = data.phone;
+  user.isAdmin = data.isAdmin ?? false;
+
+  const userRepo = em.getRepository(User);
+  userRepo.create(user);
+    
+  await em.flush();
+
+  return user;
+}

--- a/src/tests/integration/signup.test.ts
+++ b/src/tests/integration/signup.test.ts
@@ -1,0 +1,151 @@
+import request from 'supertest';
+import bcrypt from 'bcrypt'
+
+import { DI, start } from '../../index';
+import app from '../../app';
+import { User } from '../../entities/User';
+
+const API = '/api/users/signup';
+
+describe('회원가입 API POST /api/usres/signup 통합 테스트', () => {
+  beforeAll(async () => {
+    await start;
+    await DI.orm.getSchemaGenerator().refreshDatabase(); // DB 초기화
+  });
+
+  afterAll(async () => {
+    await DI.orm.close(true);
+    DI.server.close();
+  });
+
+  beforeEach(async () => {
+    DI.em = DI.orm.em.fork()
+    // 각 테스트 전에 테이블 비우기
+    await DI.em.nativeDelete(User, {})
+  });
+
+  it('일반 유저 회원가입 성공', async () => {
+    const input = {
+      username: 'test',
+      password: 'password',
+      name: 'user',
+      email: 'test@example.com',
+      phone: '010-1234-5678',
+      isAdmin: false,
+    };
+
+    const result = await request(app)
+      .post(API)
+      .send(input);
+
+    expect(result.status).toBe(201);
+    expect(result.body).toMatchObject({
+      username: input.username,
+      name: input.name,
+      email: input.email,
+      phone: input.phone,
+      isAdmin: input.isAdmin,
+    });
+
+    // 비밀번호가 해시로 저장되었는지 확인
+    const user = await DI.em.findOneOrFail(User, { username: input.username });
+    const isEqual = await bcrypt.compare(input.password, user.password);
+    expect(isEqual).toBe(true);
+  });
+
+  it('관리자 유저 회원가입 성공', async () => {
+    const input = {
+      username: 'test',
+      password: 'password',
+      name: 'user',
+      email: 'test@example.com',
+      phone: '010-1234-5678',
+      isAdmin: true,
+    };
+
+    const result = await request(app)
+      .post(API)
+      .send(input);
+
+    expect(result.status).toBe(201);
+    expect(result.body.isAdmin).toBe(true);
+  })
+
+  it('isAdmin이 주어지지 않은 경우 일반 유저로 가입 성공', async () => {
+    const input = {
+      username: 'test',
+      password: 'password',
+      name: 'user',
+      email: 'test@example.com',
+      phone: '010-1234-5678'
+    };
+
+    const result = await request(app)
+      .post(API)
+      .send(input);
+
+    expect(result.status).toBe(201);
+    expect(result.body.isAdmin).toBe(false);
+  });
+
+  it('phone이 주어지지 않은 경우 가입 성공', async () => {
+      const input = {
+        username: 'test',
+        password: 'password',
+        name: 'user',
+        email: 'test@example.com'
+      };
+  
+      const result = await request(app)
+      .post(API)
+      .send(input);
+  
+      expect(result.body.phone).toBe(undefined);
+    });
+
+    it('username이 8자를 초과한 경우 가입 실패', async () => {
+      const input = {
+        username: '123456789',
+        password: 'password',
+        name: 'user',
+        email: 'test@example.com'
+      };
+  
+      const result = await request(app)
+      .post(API)
+      .send(input);
+
+      expect(result.status).toBe(400);
+    })
+
+    it('email 형식이 틀릴 경우 가입 실패', async () => {
+      const input = {
+        username: 'test',
+        password: 'password',
+        name: 'user',
+        email: 'test@example'
+      };
+  
+      const result = await request(app)
+      .post(API)
+      .send(input);
+
+      expect(result.status).toBe(400);
+    })
+
+    it('phone 형식이 틀릴 경우 가입 실패', async () => {
+      const input = {
+        username: 'test',
+        password: 'password',
+        name: 'user',
+        email: 'test@example.com',
+        phone: '0101234'
+      };
+  
+      const result = await request(app)
+      .post(API)
+      .send(input);
+
+      expect(result.status).toBe(400);
+    })
+});

--- a/src/tests/integration/signup.test.ts
+++ b/src/tests/integration/signup.test.ts
@@ -4,6 +4,7 @@ import bcrypt from 'bcrypt'
 import { DI, start } from '../../index';
 import app from '../../app';
 import { User } from '../../entities/User';
+import { ErrorMessages } from '../../constants/error-messages';
 
 const API = '/api/users/signup';
 
@@ -31,7 +32,7 @@ describe('회원가입 API POST /api/usres/signup 통합 테스트', () => {
       name: 'user',
       email: 'test@example.com',
       phone: '010-1234-5678',
-      isAdmin: false,
+      isAdmin: false
     };
 
     const result = await request(app)
@@ -60,7 +61,7 @@ describe('회원가입 API POST /api/usres/signup 통합 테스트', () => {
       name: 'user',
       email: 'test@example.com',
       phone: '010-1234-5678',
-      isAdmin: true,
+      isAdmin: true
     };
 
     const result = await request(app)
@@ -148,4 +149,73 @@ describe('회원가입 API POST /api/usres/signup 통합 테스트', () => {
 
       expect(result.status).toBe(400);
     })
+
+    it('username이 중복인 경우 가입 실패', async () => {
+      const input = {
+      username: 'test',
+      password: 'password',
+      name: 'user',
+      email: 'test@example.com',
+      phone: '010-1234-5678'
+    };
+
+    const result1 = await request(app)
+      .post(API)
+      .send(input);
+    
+    expect(result1.status).toBe(201);
+
+    const result2 = await request(app)
+      .post(API)
+      .send({ ...input, email: 'diff@example.com', phone: '010-9876-5432' });
+    
+    expect(result2.status).toBe(400);
+    expect(result2.body.message).toBe(ErrorMessages.EXISTING_USERNAME);
+  })
+
+  it('email이 중복인 경우 가입 실패', async () => {
+      const input = {
+      username: 'test',
+      password: 'password',
+      name: 'user',
+      email: 'test@example.com',
+      phone: '010-1234-5678'
+    };
+
+    const result1 = await request(app)
+      .post(API)
+      .send(input);
+    
+    expect(result1.status).toBe(201);
+
+    const result2 = await request(app)
+      .post(API)
+      .send({ ...input, username: 'diff', phone: '010-9876-5432' });
+    
+    expect(result2.status).toBe(400);
+    expect(result2.body.message).toBe(ErrorMessages.EXISTING_EMAIL);
+  })
+
+  it('phone이 중복인 경우 가입 실패', async () => {
+      const input = {
+      username: 'test',
+      password: 'password',
+      name: 'user',
+      email: 'test@example.com',
+      phone: '010-1234-5678'
+    };
+
+    const result1 = await request(app)
+      .post(API)
+      .send(input);
+    
+    expect(result1.status).toBe(201);
+
+    const result2 = await request(app)
+      .post(API)
+      .send({ ...input, username: 'diff', email: 'diff@example.com' });
+    
+    expect(result2.status).toBe(400);
+    expect(result2.body.message).toBe(ErrorMessages.EXISTING_PHONE);
+  })
 });

--- a/src/tests/unit/userService.test.ts
+++ b/src/tests/unit/userService.test.ts
@@ -3,6 +3,7 @@ import bcrypt from 'bcrypt';
 
 import { createUser } from '../../services/userService';
 import { User } from '../../entities/User';
+import { ErrorMessages } from '../../constants/error-messages';
 
 jest.mock('bcrypt');
 
@@ -13,11 +14,12 @@ describe('createUser unit test - 회원가입 관련 서비스 유닛 테스트'
   beforeEach(() => {
     userRepo = {
       create: jest.fn(),
+      findOne: jest.fn()
     } as unknown as EntityRepository<User>;
 
     em = {
       getRepository: jest.fn(() => userRepo),
-      flush: jest.fn(),
+      flush: jest.fn()
     } as unknown as EntityManager;
   });
 
@@ -86,5 +88,46 @@ describe('createUser unit test - 회원가입 관련 서비스 유닛 테스트'
     const result = await createUser(em, input);
 
     expect(result.phone).toBe(undefined);
+  });
+
+  it('username 중복 시 에러 발생', async () => {
+    const input = {
+      username: 'test',
+      password: 'password',
+      name: 'user',
+      email: 'test@example.com',
+      phone: '010-1234-5678'
+    };
+
+    (userRepo.findOne as jest.Mock).mockResolvedValue({ username: input.username });
+
+    await expect(createUser(em, input)).rejects.toThrow(ErrorMessages.EXISTING_USERNAME);
+  });
+
+  it('email 중복 시 에러 발생', async () => {
+    const input = {
+      username: 'test',
+      password: 'password',
+      name: 'user',
+      email: 'test@example.com'
+    };
+
+    (userRepo.findOne as jest.Mock).mockResolvedValue({ email: input.email });
+
+    await expect(createUser(em, input)).rejects.toThrow(ErrorMessages.EXISTING_EMAIL);
+  });
+
+  it('phone 중복 시 에러 발생', async () => {
+    const input = {
+      username: 'test',
+      password: 'password',
+      name: 'user',
+      email: 'test@example.com',
+      phone: '010-1234-5678'
+    };
+
+    (userRepo.findOne as jest.Mock).mockResolvedValue({ phone: input.phone });
+
+    await expect(createUser(em, input)).rejects.toThrow(ErrorMessages.EXISTING_PHONE);
   });
 });

--- a/src/tests/unit/userService.test.ts
+++ b/src/tests/unit/userService.test.ts
@@ -23,7 +23,7 @@ describe('createUser unit test - 회원가입 관련 서비스 유닛 테스트'
     } as unknown as EntityManager;
   });
 
-  it('일반 유저 회원가입 성공', async () => {
+  it('user 저장 성공', async () => {
     const input = {
       username: 'test',
       password: 'password',
@@ -48,7 +48,7 @@ describe('createUser unit test - 회원가입 관련 서비스 유닛 테스트'
     });
   });
 
-  it('관리자 유저 회원가입 성공', async () => {
+  it('isAdmin이 true인 유저 저장 성공', async () => {
     const input = {
       username: 'test',
       password: 'password',
@@ -63,7 +63,7 @@ describe('createUser unit test - 회원가입 관련 서비스 유닛 테스트'
     expect(result.isAdmin).toBe(true);
   });
 
-  it('isAdmin이 주어지지 않은 경우 일반 유저로 가입 성공', async () => {
+  it('isAdmin이 없는 user 저장 성공', async () => {
     const input = {
       username: 'test',
       password: 'password',
@@ -77,7 +77,7 @@ describe('createUser unit test - 회원가입 관련 서비스 유닛 테스트'
     expect(result.isAdmin).toBe(false);
   });
 
-  it('phone이 주어지지 않은 경우 가입 성공', async () => {
+  it('phone이 없는 user 저장 성공', async () => {
     const input = {
       username: 'test',
       password: 'password',

--- a/src/tests/unit/userService.test.ts
+++ b/src/tests/unit/userService.test.ts
@@ -1,15 +1,22 @@
-import { EntityManager } from '@mikro-orm/postgresql';
+import { EntityManager, EntityRepository } from '@mikro-orm/postgresql';
 import bcrypt from 'bcrypt';
 
 import { createUser } from '../../services/userService';
+import { User } from '../../entities/User';
 
 jest.mock('bcrypt');
 
 describe('createUser unit test - 회원가입 관련 서비스 유닛 테스트', () => {
   let em: EntityManager;
+  let userRepo: EntityRepository<User>;
 
   beforeEach(() => {
+    userRepo = {
+      create: jest.fn(),
+    } as unknown as EntityRepository<User>;
+
     em = {
+      getRepository: jest.fn(() => userRepo),
       flush: jest.fn(),
     } as unknown as EntityManager;
   });

--- a/src/tests/unit/userService.test.ts
+++ b/src/tests/unit/userService.test.ts
@@ -1,0 +1,83 @@
+import { EntityManager } from '@mikro-orm/postgresql';
+import bcrypt from 'bcrypt';
+
+import { createUser } from '../../services/userService';
+
+jest.mock('bcrypt');
+
+describe('createUser unit test - 회원가입 관련 서비스 유닛 테스트', () => {
+  let em: EntityManager;
+
+  beforeEach(() => {
+    em = {
+      flush: jest.fn(),
+    } as unknown as EntityManager;
+  });
+
+  it('일반 유저 회원가입 성공', async () => {
+    const input = {
+      username: 'test',
+      password: 'password',
+      name: 'user',
+      email: 'test@example.com',
+      phone: '010-1234-5678',
+      isAdmin: false,
+    };
+
+    const hashedPassword = 'hashedpassword';
+    (bcrypt.hash as jest.Mock).mockResolvedValue(hashedPassword);
+
+    const result = await createUser(em, input);
+
+    expect(result).toMatchObject({
+      username: input.username,
+      password: hashedPassword,
+      name: input.name,
+      email: input.email,
+      phone: input.phone,
+      isAdmin: input.isAdmin,
+    });
+  });
+
+  it('관리자 유저 회원가입 성공', async () => {
+    const input = {
+      username: 'test',
+      password: 'password',
+      name: 'user',
+      email: 'test@example.com',
+      phone: '010-1234-5678',
+      isAdmin: true,
+    };
+
+    const result = await createUser(em, input);
+
+    expect(result.isAdmin).toBe(true);
+  });
+
+  it('isAdmin이 주어지지 않은 경우 일반 유저로 가입 성공', async () => {
+    const input = {
+      username: 'test',
+      password: 'password',
+      name: 'user',
+      email: 'test@example.com',
+      phone: '010-1234-5678'
+    };
+
+    const result = await createUser(em, input);
+
+    expect(result.isAdmin).toBe(false);
+  });
+
+  it('phone이 주어지지 않은 경우 가입 성공', async () => {
+    const input = {
+      username: 'test',
+      password: 'password',
+      name: 'user',
+      email: 'test@example.com'
+    };
+
+    const result = await createUser(em, input);
+
+    expect(result.phone).toBe(undefined);
+  });
+});


### PR DESCRIPTION
## 회원가입 API 작성
### Entity 생성
* **BaseEntity class**: 실제로 DB에 생성되는 엔티티는 아니지만, 모든 엔티티에 공통적인 필드를 갖고 있는 추상 클래스
* **User Entity** 생성 (username, password, name, email, phone, isAdmin)
  * username, email, phone: unique
  * phone: nullable
  * isAdmin: defalut false (일반 사용자)

### 회원가입 로직
* 미들웨어에서 유효성 검사하여 조건에 틀릴 경우 예외 처리
* username, email, phone으로 DB 조회하여 중복인 경우 예외 처리
* 그 외 성공