### PR TITLE
M클래스 생성 API 작성 (POST /api/mclasses)

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -3,6 +3,7 @@ import { RequestContext } from '@mikro-orm/postgresql';
 
 import { DI } from './index';
 import { userRouter } from './routes/userRoutes';
+import { mclassRouter } from './routes/mclassRoutes';
 
 const app = express();
 app.use(express.json());
@@ -12,5 +13,6 @@ app.use((req, res, next) => {
 });
 
 app.use('/api/users', userRouter);
+app.use('/api/mclasses', mclassRouter);
 
 export default app;

--- a/src/constants/error-messages.ts
+++ b/src/constants/error-messages.ts
@@ -5,17 +5,29 @@ export const ErrorMessages = {
 
   STRING: '문자열 형식이어야 합니다.',
   BOOLEAN: '불린 형식이어야 합니다.',
+  INT: '정수 형식이어야 합니다.',
 
   USERNAME_LENGTH: '아이디는 8자 이하여야 합니다.',
   NAME_LENGTH: '이름은 8자 이하여야 합니다.',
   PASSWORD_LENGTH: '비밀번호는 15자 이하여야 합니다.',
+  TITLE_LENGTH: '제목은 50자 이하여야 합니다.',
+  DESCRIPTION_LENGTH: '설명은 1000자 이하여야 합니다.',
+
+  MAX_PEOPLE_MINIMUM: '정원은 1명 이상이어야 합니다.',
+  FEE_MINIMUM: '참가 비용은 0 이상이어야 합니다.',
     
   INVALID_EMAIL: '올바른 이메일 형식이 아닙니다.',
   INVALID_PHONE: '올바른 휴대폰 번호 형식이 아닙니다.',
+  INVALID_DATE: '올바른 날짜 형식이 아닙니다.',
+
+  WRONG_DATE: '유효하지 않은 날짜입니다.',
 
   EXISTING_USERNAME: '중복된 아이디입니다.',
   EXISTING_EMAIL: '중복된 이메일입니다.',
   EXISTING_PHONE: '중복된 휴대폰 번호입니다.',
 
-  LOGIN_FAILED: '로그인 실패'
+  LOGIN_FAILED: '로그인 실패',
+
+  UNAUTHORIZED: '유효하지 않은 토큰입니다.',
+  FORBIDDEN: '권한이 없습니다.'
 };

--- a/src/controllers/mclassController.ts
+++ b/src/controllers/mclassController.ts
@@ -1,0 +1,23 @@
+import { Request, Response } from 'express';
+import { EntityManager, RequestContext } from '@mikro-orm/postgresql';
+
+import { createMClass } from '../services/mclassService';
+import { assertAdmin } from '../utils/permissions';
+import { ErrorMessages } from '../constants/error-messages';
+
+export const create = async (req: Request, res: Response) => {
+  try {
+    assertAdmin(req.user);
+
+    const em = RequestContext.getEntityManager() as EntityManager;
+    const mclass = await createMClass(em, req.body, req.user!);
+
+    return res.status(201).json(mclass);
+  } catch (err: any) {
+    if (err.message === ErrorMessages.FORBIDDEN) {
+      return res.status(403).json({ message: err.message });
+    }
+    
+    return res.status(400).json({ message: err.message });
+  }
+};

--- a/src/dtos/CreateMClassDto.ts
+++ b/src/dtos/CreateMClassDto.ts
@@ -1,0 +1,32 @@
+import { IsString, Length, IsOptional, IsInt, Min, IsDateString, IsNotEmpty } from 'class-validator';
+
+import { ErrorMessages } from '../constants/error-messages';
+
+export class CreateMClassDto {
+  @IsString({ message: ErrorMessages.STRING })
+  @Length(1, 50, { message: ErrorMessages.TITLE_LENGTH })
+  @IsNotEmpty({ message: ErrorMessages.REQUIRED })
+  title: string;
+
+  @IsOptional()
+  @IsString({ message: ErrorMessages.STRING })
+  @Length(0, 1000, { message: ErrorMessages.DESCRIPTION_LENGTH })
+  description?: string;
+
+  @IsInt({ message: ErrorMessages.INT })
+  @Min(1, { message: ErrorMessages.MAX_PEOPLE_MINIMUM })
+  maxPeople: number;
+
+  @IsDateString({}, { message: ErrorMessages.INVALID_DATE })
+  deadline: string;
+
+  @IsDateString({}, { message: ErrorMessages.INVALID_DATE })
+  startAt: string;
+
+  @IsDateString({}, { message: ErrorMessages.INVALID_DATE })
+  endAt: string;
+
+  @IsInt({ message: ErrorMessages.INT })
+  @Min(0, { message: ErrorMessages.FEE_MINIMUM })
+  fee: number;
+}

--- a/src/dtos/UserPayload.ts
+++ b/src/dtos/UserPayload.ts
@@ -1,0 +1,13 @@
+export interface UserPayload {
+  id: number;
+  username: string;
+  isAdmin: boolean;
+}
+
+declare global {
+  namespace Express {
+    interface Request {
+      user?: UserPayload;
+    }
+  }
+}

--- a/src/entities/MClass.ts
+++ b/src/entities/MClass.ts
@@ -1,0 +1,31 @@
+import { Entity, Property, ManyToOne } from '@mikro-orm/postgresql';
+
+import { BaseEntity } from './BaseEntity';
+import { User } from './User';
+
+@Entity()
+export class MClass extends BaseEntity {
+  @Property({ length: 50 })
+  title!: string;
+
+  @Property({ length: 1000, nullable: true })
+  description?: string;
+
+  @Property()
+  maxPeople!: number;
+
+  @Property()
+  deadline!: Date;
+
+  @Property()
+  startAt!: Date;
+
+  @Property()
+  endAt!: Date;
+
+  @Property()
+  fee!: number;
+
+  @ManyToOne(() => User, { deleteRule: 'restrict' })
+  createdUser!: User;
+}

--- a/src/middlewares/authenticate.ts
+++ b/src/middlewares/authenticate.ts
@@ -1,0 +1,26 @@
+import { Request, Response, NextFunction } from 'express';
+import jwt from 'jsonwebtoken';
+
+import { ENV } from '../config/env';
+import { ErrorMessages } from '../constants/error-messages';
+
+export const verifyJwt = (req: Request, res: Response, next: NextFunction) => {
+  const auth = req.headers.authorization;
+  if (!auth || !auth.startsWith('Bearer ')) {
+    return res.status(401).json({ message: ErrorMessages.UNAUTHORIZED });
+  }
+
+  const token = auth.split(' ')[1];
+  try {
+    const payload = jwt.verify(token, ENV.JWT.SECRET_KEY) as any;
+    req.user = {
+      id: payload.id,
+      username: payload.username,
+      isAdmin: payload.isAdmin,
+    };
+    
+    return next();
+  } catch (err: any) {
+    return res.status(401).json({ message: ErrorMessages.UNAUTHORIZED });
+  }
+};

--- a/src/mikro-orm.config.ts
+++ b/src/mikro-orm.config.ts
@@ -2,10 +2,11 @@ import { Options, PostgreSqlDriver } from '@mikro-orm/postgresql';
 import { TsMorphMetadataProvider } from '@mikro-orm/reflection';
 
 import { User } from './entities/User';
+import { MClass } from './entities/MClass';
 import { ENV } from './config/env';
 
 const config: Options = {
-  entities: [User],
+  entities: [User, MClass],
   dbName: ENV.DB.NAME,
   driver: PostgreSqlDriver,
   user: ENV.DB.USER,

--- a/src/routes/mclassRoutes.ts
+++ b/src/routes/mclassRoutes.ts
@@ -1,0 +1,12 @@
+import { Router } from 'express';
+
+import { validateDto } from '../middlewares/validate';
+import { CreateMClassDto } from '../dtos/CreateMClassDto';
+import { verifyJwt } from '../middlewares/authenticate';
+import { create } from '../controllers/mclassController';
+
+const router = Router();
+
+router.post('/', verifyJwt, validateDto(CreateMClassDto), create);
+
+export const mclassRouter = router;

--- a/src/services/mclassService.ts
+++ b/src/services/mclassService.ts
@@ -1,0 +1,51 @@
+import { EntityManager } from '@mikro-orm/postgresql';
+
+import { UserPayload } from '../dtos/UserPayload';
+import { CreateMClassDto } from '../dtos/CreateMClassDto';
+import { MClass } from '../entities/MClass';
+import { User } from '../entities/User';
+import { ErrorMessages } from '../constants/error-messages';
+
+export async function createMClass(em: EntityManager, data: CreateMClassDto, requestUser: UserPayload) {
+  const deadline = new Date(data.deadline);
+  const startAt = new Date(data.startAt);
+  const endAt = new Date(data.endAt);
+  validateDate(deadline, startAt, endAt);
+
+  const userRef = em.getReference(User, requestUser.id);
+
+  const repo = em.getRepository(MClass);
+
+  const mclass = new MClass();
+  mclass.title = data.title;
+  mclass.description = data.description;
+  mclass.maxPeople = data.maxPeople;
+  mclass.deadline = deadline;
+  mclass.startAt = startAt;
+  mclass.endAt = endAt;
+  mclass.fee = data.fee;
+  mclass.createdUser = userRef;
+
+  repo.create(mclass);
+  await em.flush();
+
+  return mclass;
+}
+
+function validateDate(deadline: Date, startAt: Date, endAt: Date) {
+  const now = new Date();
+  // 마감 시간 및 시작 시간은 현재 시간보다 커야 함
+  if (deadline <= now || startAt <= now) {
+    throw new Error(ErrorMessages.WRONG_DATE);
+  }
+
+  // 시작일시는 마감 시간보다 커야 함
+  if (startAt <= deadline) {
+    throw new Error(ErrorMessages.WRONG_DATE);
+  }
+
+  // 종료일시는 시작일시보다 커야 함
+  if (endAt <= startAt) {
+    throw new Error(ErrorMessages.WRONG_DATE);
+  }
+}

--- a/src/tests/integration/mclasses-post.test.ts
+++ b/src/tests/integration/mclasses-post.test.ts
@@ -1,0 +1,130 @@
+import request from 'supertest';
+
+import { DI, start } from '../../index';
+import app from '../../app';
+import { MClass } from '../../entities/MClass';
+import { ErrorMessages } from '../../constants/error-messages';
+
+const API = '/api/mclasses';
+
+describe('M클래스 생성 API POST /api/mclasses 통합 테스트', () => {
+  let requestUserId: number;
+  let adminToken: string;
+
+  const adminUserData = {
+    username: 'admin',
+    password: 'password',
+    name: 'admin',
+    email: 'admin@example.com',
+    isAdmin: true
+  };
+
+  beforeAll(async () => {
+    await start;
+    await DI.orm.getSchemaGenerator().refreshDatabase();
+
+    const signupResult = await request(app).post('/api/users/signup').send(adminUserData);
+    const LoginResult = await request(app).post('/api/users/login').send(adminUserData);
+
+    requestUserId = signupResult.body.id;
+    adminToken = LoginResult.body.accessToken;
+  });
+
+  afterAll(async () => {
+    await DI.orm.close(true);
+    DI.server.close();
+  });
+
+  beforeEach(async () => {
+    DI.em = DI.orm.em.fork();
+    await DI.em.nativeDelete(MClass, {});
+  });
+
+  it('M클래스 생성 성공', async () => {
+    const input = {
+      title: 'test class',
+      description: 'class description',
+      maxPeople: 10,
+      deadline: new Date(Date.now() + 1000 * 60).toISOString(),
+      startAt: new Date(Date.now() + 1000 * 60 * 60).toISOString(),
+      endAt: new Date(Date.now() + 1000 * 60 * 60 * 2).toISOString(),
+      fee: 100
+    };
+
+    const result = await request(app).post(API).set('Authorization', `Bearer ${adminToken}`).send(input)
+
+    expect(result.status).toBe(201);
+    expect(result.body).toMatchObject({
+      title: input.title,
+      description: input.description,
+      maxPeople: input.maxPeople,
+      deadline: input.deadline,
+      startAt: input.startAt,
+      endAt: input.endAt,
+      fee: input.fee,
+      createdUser: requestUserId
+    });
+  });
+
+  it('JWT 토큰이 없는 경우 실패', async () => {
+    const input = {
+      title: 'test class',
+      description: 'class description',
+      maxPeople: 10,
+      deadline: new Date(Date.now() + 1000 * 60).toISOString(),
+      startAt: new Date(Date.now() + 1000 * 60 * 60).toISOString(),
+      endAt: new Date(Date.now() + 1000 * 60 * 60 * 2).toISOString(),
+      fee: 100
+    };
+
+    const result = await request(app).post(API).send(input)
+
+    expect(result.status).toBe(401);
+    expect(result.body.message).toBe(ErrorMessages.UNAUTHORIZED);
+  });
+
+  it('관리자가 아닌 유저가 요청한 경우 실패', async () => {
+    const commonUserData = {
+        username: 'common',
+        password: 'password',
+        name: 'common',
+        email: 'common@example.com',
+        isAdmin: false
+    };
+    await request(app).post('/api/users/signup').send(commonUserData);
+    const LoginResult = await request(app).post('/api/users/login').send(commonUserData);
+    const commomToken = LoginResult.body.accessToken;
+
+    const input = {
+      title: 'test class',
+      description: 'class description',
+      maxPeople: 10,
+      deadline: new Date(Date.now() + 1000 * 60).toISOString(),
+      startAt: new Date(Date.now() + 1000 * 60 * 60).toISOString(),
+      endAt: new Date(Date.now() + 1000 * 60 * 60 * 2).toISOString(),
+      fee: 100
+    };
+
+    const result = await request(app).post(API).set('Authorization', `Bearer ${commomToken}`).send(input)
+
+    expect(result.status).toBe(403);
+    expect(result.body.message).toBe(ErrorMessages.FORBIDDEN);
+  });
+
+  it('maxPeople가 1 미만인 경우 실패', async () => {
+    const input = {
+      title: 'test class',
+      description: 'class description',
+      maxPeople: 0,
+      deadline: new Date(Date.now() + 1000 * 60).toISOString(),
+      startAt: new Date(Date.now() + 1000 * 60 * 60).toISOString(),
+      endAt: new Date(Date.now() + 1000 * 60 * 60 * 2).toISOString(),
+      fee: 100
+    };
+
+    const result = await request(app).post(API).set('Authorization', `Bearer ${adminToken}`).send(input)
+
+    expect(result.status).toBe(400);
+    expect(result.body.message).toBe(ErrorMessages.VALIDATION_FAILED);
+  });
+});

--- a/src/tests/unit/mclassService.test.ts
+++ b/src/tests/unit/mclassService.test.ts
@@ -1,0 +1,108 @@
+import { EntityManager, EntityRepository } from '@mikro-orm/postgresql';
+
+import { createMClass } from '../../services/mclassService';
+import { MClass } from '../../entities/MClass';
+import { ErrorMessages } from '../../constants/error-messages';
+
+describe('createMClass unit test - M클래스 생성 관련 서비스 유닛 테스트', () => {
+  let em: EntityManager;
+  let mclassRepo: EntityRepository<MClass>;
+
+  const requestUser = {
+    id: 1,
+    username: 'test',
+    isAdmin: true
+  };
+
+  beforeEach(() => {
+    mclassRepo = {
+        create: jest.fn()
+    } as unknown as EntityRepository<MClass>;
+
+    em = {
+      getRepository: jest.fn(() => mclassRepo),
+      flush: jest.fn(),
+    } as unknown as EntityManager;
+  });
+
+  it('mclass 저장 성공', async () => {
+    const input = {
+      title: 'test class',
+      description: 'class description',
+      maxPeople: 10,
+      deadline: new Date(Date.now() + 1000 * 60).toISOString(),
+      startAt: new Date(Date.now() + 1000 * 60 * 60).toISOString(),
+      endAt: new Date(Date.now() + 1000 * 60 * 60 * 2).toISOString(),
+      fee: 100
+    };
+
+    const result = await createMClass(em, input, requestUser);
+
+    expect(result).toMatchObject({
+      title: input.title,
+      description: input.description,
+      maxPeople: input.maxPeople,
+      deadline: new Date(input.deadline),
+      startAt: new Date(input.startAt),
+      endAt: new Date(input.endAt),
+      fee: input.fee,
+      createdUser: requestUser.id
+    });
+  });
+
+  it('deadline이 과거인 경우 실패', async () => {
+    const input = {
+      title: 'test class',
+      description: 'class description',
+      maxPeople: 10,
+      deadline: new Date(Date.now() - 1000 * 60).toISOString(),
+      startAt: new Date(Date.now() + 1000 * 60 * 60).toISOString(),
+      endAt: new Date(Date.now() + 1000 * 60 * 60 * 2).toISOString(),
+      fee: 100
+    };
+
+    await expect(createMClass(em, input, requestUser)).rejects.toThrow(ErrorMessages.WRONG_DATE);
+  });
+
+  it('startAt이 과거인 경우 실패', async () => {
+    const input = {
+      title: 'test class',
+      description: 'class description',
+      maxPeople: 10,
+      deadline: new Date(Date.now() + 1000 * 60).toISOString(),
+      startAt: new Date(Date.now() - 1000 * 60 * 60).toISOString(),
+      endAt: new Date(Date.now() + 1000 * 60 * 60 * 2).toISOString(),
+      fee: 100
+    };
+
+    await expect(createMClass(em, input, requestUser)).rejects.toThrow(ErrorMessages.WRONG_DATE);
+  });
+
+  it('startAt이 deadline보다 작은 경우 실패', async () => {
+    const input = {
+      title: 'test class',
+      description: 'class description',
+      maxPeople: 10,
+      deadline: new Date(Date.now() + 1000 * 60 * 60).toISOString(),
+      startAt: new Date(Date.now() + 1000 * 60).toISOString(),
+      endAt: new Date(Date.now() + 1000 * 60 * 60 * 2).toISOString(),
+      fee: 100
+    };
+
+    await expect(createMClass(em, input, requestUser)).rejects.toThrow(ErrorMessages.WRONG_DATE);
+  });
+
+  it('endAt이 startAt보다 작은 경우 실패', async () => {
+    const input = {
+      title: 'test class',
+      description: 'class description',
+      maxPeople: 10,
+      deadline: new Date(Date.now() + 1000 * 60).toISOString(),
+      startAt: new Date(Date.now() + 1000 * 60 * 60 * 2).toISOString(),
+      endAt: new Date(Date.now() + 1000 * 60 * 60).toISOString(),
+      fee: 100
+    };
+
+    await expect(createMClass(em, input, requestUser)).rejects.toThrow(ErrorMessages.WRONG_DATE);
+  });
+});

--- a/src/tests/unit/mclassService.test.ts
+++ b/src/tests/unit/mclassService.test.ts
@@ -20,6 +20,7 @@ describe('createMClass unit test - M클래스 생성 관련 서비스 유닛 테
     } as unknown as EntityRepository<MClass>;
 
     em = {
+      getReference: jest.fn(() => requestUser.id),
       getRepository: jest.fn(() => mclassRepo),
       flush: jest.fn(),
     } as unknown as EntityManager;

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -1,0 +1,8 @@
+import { UserPayload } from '../dtos/UserPayload';
+import { ErrorMessages } from '../constants/error-messages';
+
+export function assertAdmin(user?: UserPayload) {
+  if (!user || !user.isAdmin) {
+    throw new Error(ErrorMessages.FORBIDDEN);
+  }
+}


### PR DESCRIPTION
## M클래스 생성 API 작성
### M클래스 생성 로직
* JWT 검증하여 isAdmin이 true인 사용자(관리자)만 가능, 그 외 사용자 예외 처리
* 유효성 검사 실패할 경우 예외 처리
* 시간 관련 필드들 현재 시간보다 작거나 종료일시가 시작일시보다 작은 등 논리적 오류 예외 처리
* 그 외 성공

### Entity 생성
* MClass Entity 생성 (title, description, maxPeople, deadline, startAt, endAt, fee, createdUser)
  * description: nullable
  * createdUser: FK(User.id)

### express.Request에 user 필드 추가
* JWT로 검증된 사용자의 정보 저장
* id, username, isAdmin