### PR TITLE
M클래스 목록 조회 API 작성 (GET /api/mclasses)

### DIFF
--- a/src/constants/defalut-limits.ts
+++ b/src/constants/defalut-limits.ts
@@ -1,3 +1,3 @@
 export const DefaultLimits = {
-    MCLASS: 10
+  MCLASS: 10
 };

--- a/src/constants/defalut-limits.ts
+++ b/src/constants/defalut-limits.ts
@@ -1,0 +1,3 @@
+export const DefaultLimits = {
+    MCLASS: 10
+};

--- a/src/constants/error-messages.ts
+++ b/src/constants/error-messages.ts
@@ -13,6 +13,8 @@ export const ErrorMessages = {
   TITLE_LENGTH: '제목은 50자 이하여야 합니다.',
   DESCRIPTION_LENGTH: '설명은 1000자 이하여야 합니다.',
 
+  GTE_1: '1 이상이어야 합니다.',
+  LTE_100: '100 이하여야 합니다.',
   MAX_PEOPLE_MINIMUM: '정원은 1명 이상이어야 합니다.',
   FEE_MINIMUM: '참가 비용은 0 이상이어야 합니다.',
     

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,1 +1,2 @@
 export * from './error-messages';
+export * from './defalut-limits'

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,2 +1,2 @@
 export * from './error-messages';
-export * from './defalut-limits'
+export * from './defalut-limits';

--- a/src/controllers/mclassController.ts
+++ b/src/controllers/mclassController.ts
@@ -1,8 +1,9 @@
 import { NextFunction, Request, Response } from 'express';
 import { EntityManager, RequestContext } from '@mikro-orm/postgresql';
 
-import { createMClass } from '../services/mclassService';
+import { createMClass, getMClassList } from '../services/mclassService';
 import { assertAdmin } from '../utils/permissions';
+import { DefaultLimits } from '../constants';
 
 export const create = async (req: Request, res: Response, next: NextFunction) => {
   try {
@@ -14,6 +15,21 @@ export const create = async (req: Request, res: Response, next: NextFunction) =>
     return res.status(201).json(mclass);
   }
   catch (err: any) {
+    next(err);
+  }
+};
+
+export const getList = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const em = RequestContext.getEntityManager() as EntityManager;
+
+    const limit = req.query.limit ? Number(req.query.limit) : DefaultLimits.MCLASS;
+    const last = req.query.last ? Number(req.query.last) : undefined;
+
+    const mclassList = await getMClassList(em, limit, last);
+
+    return res.json({ list: mclassList });
+  } catch (err: any) {
     next(err);
   }
 };

--- a/src/controllers/mclassController.ts
+++ b/src/controllers/mclassController.ts
@@ -3,7 +3,6 @@ import { EntityManager, RequestContext } from '@mikro-orm/postgresql';
 
 import { createMClass, getMClassList } from '../services/mclassService';
 import { assertAdmin } from '../utils/permissions';
-import { DefaultLimits } from '../constants';
 
 export const create = async (req: Request, res: Response, next: NextFunction) => {
   try {
@@ -22,11 +21,7 @@ export const create = async (req: Request, res: Response, next: NextFunction) =>
 export const getList = async (req: Request, res: Response, next: NextFunction) => {
   try {
     const em = RequestContext.getEntityManager() as EntityManager;
-
-    const limit = req.query.limit ? Number(req.query.limit) : DefaultLimits.MCLASS;
-    const last = req.query.last ? Number(req.query.last) : undefined;
-
-    const mclassList = await getMClassList(em, limit, last);
+    const mclassList = await getMClassList(em, req.validatedQuery!);
 
     return res.json({ list: mclassList });
   } catch (err: any) {

--- a/src/dtos/GetMClassListQueryDto.ts
+++ b/src/dtos/GetMClassListQueryDto.ts
@@ -1,0 +1,18 @@
+import { IsInt, Min, Max, IsOptional } from 'class-validator';
+import { Type } from 'class-transformer';
+
+import { ErrorMessages, DefaultLimits } from '../constants';
+
+export class GetMClassListQueryDto {
+  @IsOptional()
+  @Min(1, { message: ErrorMessages.GTE_1 })
+  @Max(100, { message: ErrorMessages.LTE_100 })
+  @IsInt({ message: ErrorMessages.INT })
+  @Type(() => Number)
+  limit: number = DefaultLimits.MCLASS;
+
+  @IsOptional()
+  @IsInt({ message: ErrorMessages.INT })
+  @Type(() => Number)
+  last?: number = undefined;
+}

--- a/src/dtos/MClassListItemDto.ts
+++ b/src/dtos/MClassListItemDto.ts
@@ -1,0 +1,24 @@
+import { Expose, Type } from 'class-transformer';
+
+export class MClassListItemDto {
+  @Expose()
+  id: number;
+
+  @Expose()
+  title: string;
+
+  @Expose()
+  maxPeople: number;
+
+  @Expose()
+  @Type(() => Date)
+  deadline: Date;
+
+  @Expose()
+  @Type(() => Date)
+  startAt: Date;
+
+  @Expose()
+  @Type(() => Date)
+  endAt: Date;
+}

--- a/src/dtos/index.ts
+++ b/src/dtos/index.ts
@@ -2,3 +2,4 @@ export * from './CreateMClassDto';
 export * from './CreateUserDto';
 export * from './LoginDto';
 export * from './UserPayload';
+export * from './MClassListItemDto';

--- a/src/dtos/index.ts
+++ b/src/dtos/index.ts
@@ -3,3 +3,4 @@ export * from './CreateUserDto';
 export * from './LoginDto';
 export * from './UserPayload';
 export * from './MClassListItemDto';
+export * from './GetMClassListQueryDto';

--- a/src/middlewares/validate.ts
+++ b/src/middlewares/validate.ts
@@ -12,7 +12,7 @@ declare global {
   }
 }
 
-export const validateDto = (dtoClass: any) => {
+export const validateBody = (dtoClass: any) => {
   return async (req: Request, res: Response, next: NextFunction) => {
     const instance = plainToInstance(dtoClass, req.body);
     const errors = await validate(instance);

--- a/src/routes/mclassRoutes.ts
+++ b/src/routes/mclassRoutes.ts
@@ -1,13 +1,13 @@
 import { Router } from 'express';
 
 import { CreateMClassDto, GetMClassListQueryDto } from '../dtos';
-import { validateDto, validateQuery } from '../middlewares/validate';
+import { validateBody, validateQuery } from '../middlewares/validate';
 import { verifyJwt } from '../middlewares/authenticate';
 import { create, getList } from '../controllers/mclassController';
 
 const router = Router();
 
-router.post('/', verifyJwt, validateDto(CreateMClassDto), create);
+router.post('/', verifyJwt, validateBody(CreateMClassDto), create);
 router.get('/', validateQuery(GetMClassListQueryDto), getList);
 
 export const mclassRouter = router;

--- a/src/routes/mclassRoutes.ts
+++ b/src/routes/mclassRoutes.ts
@@ -3,10 +3,11 @@ import { Router } from 'express';
 import { CreateMClassDto } from '../dtos';
 import { validateDto } from '../middlewares/validate';
 import { verifyJwt } from '../middlewares/authenticate';
-import { create } from '../controllers/mclassController';
+import { create, getList } from '../controllers/mclassController';
 
 const router = Router();
 
 router.post('/', verifyJwt, validateDto(CreateMClassDto), create);
+router.get('/', getList);
 
 export const mclassRouter = router;

--- a/src/routes/mclassRoutes.ts
+++ b/src/routes/mclassRoutes.ts
@@ -1,13 +1,13 @@
 import { Router } from 'express';
 
-import { CreateMClassDto } from '../dtos';
-import { validateDto } from '../middlewares/validate';
+import { CreateMClassDto, GetMClassListQueryDto } from '../dtos';
+import { validateDto, validateQuery } from '../middlewares/validate';
 import { verifyJwt } from '../middlewares/authenticate';
 import { create, getList } from '../controllers/mclassController';
 
 const router = Router();
 
 router.post('/', verifyJwt, validateDto(CreateMClassDto), create);
-router.get('/', getList);
+router.get('/', validateQuery(GetMClassListQueryDto), getList);
 
 export const mclassRouter = router;

--- a/src/routes/userRoutes.ts
+++ b/src/routes/userRoutes.ts
@@ -1,12 +1,12 @@
 import { Router } from 'express';
 
 import { signup, login } from '../controllers/userController';
-import { validateDto } from '../middlewares/validate';
+import { validateBody } from '../middlewares/validate';
 import { CreateUserDto, LoginDto } from '../dtos';
 
 const router = Router();
 
-router.post('/signup', validateDto(CreateUserDto), signup);
-router.post('/login', validateDto(LoginDto), login);
+router.post('/signup', validateBody(CreateUserDto), signup);
+router.post('/login', validateBody(LoginDto), login);
 
 export const userRouter = router;

--- a/src/services/mclassService.ts
+++ b/src/services/mclassService.ts
@@ -1,7 +1,7 @@
 import { EntityManager, QueryOrder } from '@mikro-orm/postgresql';
 import { plainToInstance } from 'class-transformer';
 
-import { CreateMClassDto, UserPayload, MClassListItemDto } from '../dtos';
+import { CreateMClassDto, UserPayload, MClassListItemDto, GetMClassListQueryDto } from '../dtos';
 import { User, MClass } from '../entities';
 import { ErrorMessages } from '../constants';
 import { ValidationError } from '../errors';
@@ -32,11 +32,11 @@ export async function createMClass(em: EntityManager, data: CreateMClassDto, req
   return mclass;
 }
 
-export async function getMClassList(em: EntityManager, limit: number, last: number | undefined) {
+export async function getMClassList(em: EntityManager, data: GetMClassListQueryDto) {
   const repo = em.getRepository(MClass);
 
-  const where = last ? { id: { $lt: last }} : {}
-  const mclassList = await repo.find(where, { orderBy: { id: QueryOrder.DESC }, limit: limit })
+  const where = data.last ? { id: { $lt: data.last }} : {}
+  const mclassList = await repo.find(where, { orderBy: { id: QueryOrder.DESC }, limit: data.limit })
 
   return plainToInstance(MClassListItemDto, mclassList, { excludeExtraneousValues: true });
 }

--- a/src/services/mclassService.ts
+++ b/src/services/mclassService.ts
@@ -1,6 +1,7 @@
-import { EntityManager } from '@mikro-orm/postgresql';
+import { EntityManager, QueryOrder } from '@mikro-orm/postgresql';
+import { plainToInstance } from 'class-transformer';
 
-import { CreateMClassDto, UserPayload } from '../dtos';
+import { CreateMClassDto, UserPayload, MClassListItemDto } from '../dtos';
 import { User, MClass } from '../entities';
 import { ErrorMessages } from '../constants';
 import { ValidationError } from '../errors';
@@ -29,6 +30,15 @@ export async function createMClass(em: EntityManager, data: CreateMClassDto, req
   await em.flush();
 
   return mclass;
+}
+
+export async function getMClassList(em: EntityManager, limit: number, last: number | undefined) {
+  const repo = em.getRepository(MClass);
+
+  const where = last ? { id: { $lt: last }} : {}
+  const mclassList = await repo.find(where, { orderBy: { id: QueryOrder.DESC }, limit: limit })
+
+  return plainToInstance(MClassListItemDto, mclassList, { excludeExtraneousValues: true });
 }
 
 function validateDate(deadline: Date, startAt: Date, endAt: Date) {

--- a/src/services/mclassService.ts
+++ b/src/services/mclassService.ts
@@ -35,8 +35,8 @@ export async function createMClass(em: EntityManager, data: CreateMClassDto, req
 export async function getMClassList(em: EntityManager, data: GetMClassListQueryDto) {
   const repo = em.getRepository(MClass);
 
-  const where = data.last ? { id: { $lt: data.last }} : {}
-  const mclassList = await repo.find(where, { orderBy: { id: QueryOrder.DESC }, limit: data.limit })
+  const where = data.last ? { id: { $lt: data.last }} : {};
+  const mclassList = await repo.find(where, { orderBy: { id: QueryOrder.DESC }, limit: data.limit });
 
   return plainToInstance(MClassListItemDto, mclassList, { excludeExtraneousValues: true });
 }

--- a/src/tests/integration/mclasses-get.test.ts
+++ b/src/tests/integration/mclasses-get.test.ts
@@ -2,7 +2,7 @@ import request from 'supertest';
 
 import { DI, start } from '../../index';
 import app from '../../app';
-import { DefaultLimits } from '../../constants';
+import { DefaultLimits, ErrorMessages } from '../../constants';
 
 const API = '/api/mclasses';
 
@@ -54,7 +54,7 @@ describe('M클래스 목록 조회 API GET /api/mclasses 통합 테스트', () =
     const limit = 5;
     const last = 10;
     
-    const result = await request(app).get(API).query({ limit: limit, last: last});
+    const result = await request(app).get(API).query({ limit: limit, last: last });
 
     expect(result.status).toBe(200);
     expect(result.body.list).toBeInstanceOf(Array);
@@ -66,7 +66,7 @@ describe('M클래스 목록 조회 API GET /api/mclasses 통합 테스트', () =
     const limit = undefined;
     const last = 15;
     
-    const result = await request(app).get(API).query({ limit: limit, last: last});
+    const result = await request(app).get(API).query({ limit: limit, last: last });
 
     expect(result.status).toBe(200);
     expect(result.body.list).toBeInstanceOf(Array);
@@ -78,11 +78,41 @@ describe('M클래스 목록 조회 API GET /api/mclasses 통합 테스트', () =
     const limit = 5;
     const last = undefined;
     
-    const result = await request(app).get(API).query({ limit: limit, last: last});
+    const result = await request(app).get(API).query({ limit: limit, last: last });
 
     expect(result.status).toBe(200);
     expect(result.body.list).toBeInstanceOf(Array);
     expect(result.body.list.length).toBe(limit);
     expect(result.body.list[0].id).toBe(mclassListLength);
+  });
+
+  it('limit가 number가 아닐 경우 실패', async () => {
+    const limit = 'wrong';
+    const last = 10;
+    
+    const result = await request(app).get(API).query({ limit: limit, last: last });
+
+    expect(result.status).toBe(400);
+    expect(result.body.message).toBe(ErrorMessages.VALIDATION_FAILED);
+  });
+
+  it('limit가 1 미만인 경우 실패', async () => {
+    const limit = 0;
+    const last = 10;
+    
+    const result = await request(app).get(API).query({ limit: limit, last: last });
+
+    expect(result.status).toBe(400);
+    expect(result.body.message).toBe(ErrorMessages.VALIDATION_FAILED);
+  });
+
+  it('limit가 100 초과인 경우 실패', async () => {
+    const limit = 101;
+    const last = 10;
+    
+    const result = await request(app).get(API).query({ limit: limit, last: last });
+
+    expect(result.status).toBe(400);
+    expect(result.body.message).toBe(ErrorMessages.VALIDATION_FAILED);
   });
 });

--- a/src/tests/integration/mclasses-get.test.ts
+++ b/src/tests/integration/mclasses-get.test.ts
@@ -1,0 +1,88 @@
+import request from 'supertest';
+
+import { DI, start } from '../../index';
+import app from '../../app';
+import { DefaultLimits } from '../../constants';
+
+const API = '/api/mclasses';
+
+describe('M클래스 목록 조회 API GET /api/mclasses 통합 테스트', () => {
+  let adminToken: string;
+
+  const mclassListLength = 15;
+  const adminUserData = {
+    username: 'admin',
+    password: 'password',
+    name: 'admin',
+    email: 'admin@example.com',
+    isAdmin: true
+  };
+
+  beforeAll(async () => {
+    await start;
+    await DI.orm.getSchemaGenerator().refreshDatabase();
+
+    await request(app).post('/api/users/signup').send(adminUserData);
+    const LoginResult = await request(app).post('/api/users/login').send(adminUserData);
+    adminToken = LoginResult.body.accessToken;
+
+    const mclassData = {
+      title: 'test class',
+      description: 'class description',
+      maxPeople: 10,
+      deadline: new Date(Date.now() + 1000 * 60).toISOString(),
+      startAt: new Date(Date.now() + 1000 * 60 * 60).toISOString(),
+      endAt: new Date(Date.now() + 1000 * 60 * 60 * 2).toISOString(),
+      fee: 100
+    };
+    const mclassListData = new Array(mclassListLength).fill(0).map(() => ({ ...mclassData }));
+    for (const data of mclassListData) {
+      await request(app).post(API).set('Authorization', `Bearer ${adminToken}`).send(data)
+    }
+  });
+
+  afterAll(async () => {
+    await DI.orm.close(true);
+    DI.server.close();
+  });
+
+  beforeEach(async () => {
+    DI.em = DI.orm.em.fork();
+  });
+
+  it('M클래스 목록 조회 성공', async () => {
+    const limit = 5;
+    const last = 10;
+    
+    const result = await request(app).get(API).query({ limit: limit, last: last});
+
+    expect(result.status).toBe(200);
+    expect(result.body.list).toBeInstanceOf(Array);
+    expect(result.body.list.length).toBe(limit);
+    expect(result.body.list[0].id).toBe(last - 1);
+  });
+
+  it(`limit가 없는 경우 M클래스 목록 ${DefaultLimits.MCLASS} 개 조회 성공`, async () => {
+    const limit = undefined;
+    const last = 15;
+    
+    const result = await request(app).get(API).query({ limit: limit, last: last});
+
+    expect(result.status).toBe(200);
+    expect(result.body.list).toBeInstanceOf(Array);
+    expect(result.body.list.length).toBe(DefaultLimits.MCLASS);
+    expect(result.body.list[0].id).toBe(last - 1);
+  });
+
+  it('last가 없는 경우 M클래스 목록 조회 성공', async () => {
+    const limit = 5;
+    const last = undefined;
+    
+    const result = await request(app).get(API).query({ limit: limit, last: last});
+
+    expect(result.status).toBe(200);
+    expect(result.body.list).toBeInstanceOf(Array);
+    expect(result.body.list.length).toBe(limit);
+    expect(result.body.list[0].id).toBe(mclassListLength);
+  });
+});

--- a/src/tests/unit/mclassService.test.ts
+++ b/src/tests/unit/mclassService.test.ts
@@ -125,20 +125,24 @@ describe('getMClassList unit test - M클래스 목록 조회 관련 서비스 �
   });
 
   it('mclass 목록 조회 성공', async () => {
-    const limit = 10;
-    const last = 1;
+    const input = {
+      limit: 10,
+      last: 1
+    }
 
-    await getMClassList(em, limit, last);
+    await getMClassList(em, input);
 
-    expect(mclassRepo.find).toHaveBeenCalledWith({ id: { $lt: last } },{ orderBy: { id: QueryOrder.DESC },limit: limit });
+    expect(mclassRepo.find).toHaveBeenCalledWith({ id: { $lt: input.last } },{ orderBy: { id: QueryOrder.DESC },limit: input.limit });
   });
 
   it('last가 없는 경우 where 없이 mclass 목록 조회 성공', async () => {
-    const limit = 10;
-    const last = undefined;
+    const input = {
+      limit: 10,
+      last: undefined
+    }
 
-    await getMClassList(em, limit, last);
+    await getMClassList(em, input);
 
-    expect(mclassRepo.find).toHaveBeenCalledWith({},{ orderBy: { id: QueryOrder.DESC },limit: limit });
+    expect(mclassRepo.find).toHaveBeenCalledWith({},{ orderBy: { id: QueryOrder.DESC },limit: input.limit });
   })
 });

--- a/src/tests/unit/mclassService.test.ts
+++ b/src/tests/unit/mclassService.test.ts
@@ -1,6 +1,6 @@
-import { EntityManager, EntityRepository } from '@mikro-orm/postgresql';
+import { EntityManager, EntityRepository, QueryOrder } from '@mikro-orm/postgresql';
 
-import { createMClass } from '../../services/mclassService';
+import { createMClass, getMClassList } from '../../services/mclassService';
 import { MClass } from '../../entities';
 import { ErrorMessages } from '../../constants';
 
@@ -16,13 +16,13 @@ describe('createMClass unit test - M클래스 생성 관련 서비스 유닛 테
 
   beforeEach(() => {
     mclassRepo = {
-        create: jest.fn()
+      create: jest.fn()
     } as unknown as EntityRepository<MClass>;
 
     em = {
       getReference: jest.fn(() => requestUser.id),
       getRepository: jest.fn(() => mclassRepo),
-      flush: jest.fn(),
+      flush: jest.fn()
     } as unknown as EntityManager;
   });
 
@@ -106,4 +106,39 @@ describe('createMClass unit test - M클래스 생성 관련 서비스 유닛 테
 
     await expect(createMClass(em, input, requestUser)).rejects.toThrow(ErrorMessages.WRONG_DATE);
   });
+});
+
+describe('getMClassList unit test - M클래스 목록 조회 관련 서비스 유닛 테스트', () => {
+  let em: EntityManager;
+  let mclassRepo: EntityRepository<MClass>;
+
+  const mclassListData = [{ id:1 }, { id: 2 }, { id: 3 }]
+
+  beforeEach(() => {
+    mclassRepo = {
+      find: jest.fn(() => mclassListData)
+    } as unknown as EntityRepository<MClass>;
+
+    em = {
+      getRepository: jest.fn(() => mclassRepo)
+    } as unknown as EntityManager;
+  });
+
+  it('mclass 목록 조회 성공', async () => {
+    const limit = 10;
+    const last = 1;
+
+    await getMClassList(em, limit, last);
+
+    expect(mclassRepo.find).toHaveBeenCalledWith({ id: { $lt: last } },{ orderBy: { id: QueryOrder.DESC },limit: limit });
+  });
+
+  it('last가 없는 경우 where 없이 mclass 목록 조회 성공', async () => {
+    const limit = 10;
+    const last = undefined;
+
+    await getMClassList(em, limit, last);
+
+    expect(mclassRepo.find).toHaveBeenCalledWith({},{ orderBy: { id: QueryOrder.DESC },limit: limit });
+  })
 });


### PR DESCRIPTION
## M클래스 목록 조회 API 작성
### M클래스 조회 로직
* 쿼리 스트링 필요
  * **limit**: number, optional, default 10, min 1, max 100, 몇 개의 M클래스를 조회할 것인지
  * **last**: number, optional, 마지막으로 조회된 M클래스 id, last 다음부터 조회, 없을 시 가장 최근부터 조회
* 최신순 조회
* 유효성 검사 실패할 경우 예외 처리
* 그 외 성공

### express.Request에 validatedQuery 필드 추가
* 유효성 검사를 통과한 쿼리 스트링 데이터 저장

## 그 외 변경 사항
### validateDto 함수명 validateBody로 변경
* 새로 추가한 쿼리 스트링 유효성 검증하는 함수인 validateQuery와 명확히 구분하기 위해 변경
  * 그에 따른 코드 수정