### PR TITLE
M클래스 삭제 API 작성 (DELETE /api/mclasses/:id)

### DIFF
--- a/src/constants/error-messages.ts
+++ b/src/constants/error-messages.ts
@@ -33,7 +33,7 @@ export const ErrorMessages = {
 
   UNAUTHORIZED: '인증 실패',
   FORBIDDEN: '권한이 없습니다.',
-  NOT_FOUND: '존재하지 않습니다',
+  NOT_FOUND: '존재하지 않습니다.',
 
   UNHANDLED_ERROR: '처리하지 못한 에러'
 };

--- a/src/controllers/mclassController.ts
+++ b/src/controllers/mclassController.ts
@@ -1,7 +1,7 @@
 import { NextFunction, Request, Response } from 'express';
 import { EntityManager, RequestContext } from '@mikro-orm/postgresql';
 
-import { createMClass, getMClassById, getMClassList } from '../services/mclassService';
+import { createMClass, getMClassById, getMClassList, deleteMClassById } from '../services/mclassService';
 import { assertAdmin } from '../utils/permissions';
 
 export const create = async (req: Request, res: Response, next: NextFunction) => {
@@ -40,4 +40,18 @@ export const getDetail = async (req: Request, res: Response, next: NextFunction)
   catch (err: any) {
     next(err);
   }
-}
+};
+
+export const deleteMclass = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    assertAdmin(req.user);
+
+    const em = RequestContext.getEntityManager() as EntityManager;
+    const deletedId = await deleteMClassById(em, Number(req.params.id));
+
+    return res.json({ id: deletedId });
+  }
+  catch (err: any) {
+    next(err);
+  }
+};

--- a/src/entities/MClass.ts
+++ b/src/entities/MClass.ts
@@ -26,6 +26,9 @@ export class MClass extends BaseEntity {
   @Property()
   fee!: number;
 
+  @Property()
+  isDelete: boolean = false;
+
   @ManyToOne(() => User, { deleteRule: 'restrict' })
   createdUser!: User;
 }

--- a/src/routes/mclassRoutes.ts
+++ b/src/routes/mclassRoutes.ts
@@ -3,12 +3,13 @@ import { Router } from 'express';
 import { CreateMClassDto, GetMClassListQueryDto, IdParamDto } from '../dtos';
 import { validateBody, validateQuery, validateParam } from '../middlewares/validate';
 import { verifyJwt } from '../middlewares/authenticate';
-import { create, getList, getDetail } from '../controllers/mclassController';
+import { create, getList, getDetail, deleteMclass } from '../controllers/mclassController';
 
 const router = Router();
 
 router.post('/', verifyJwt, validateBody(CreateMClassDto), create);
 router.get('/', validateQuery(GetMClassListQueryDto), getList);
 router.get('/:id', validateParam(IdParamDto), getDetail);
+router.delete('/:id', verifyJwt, validateParam(IdParamDto), deleteMclass);
 
 export const mclassRouter = router;

--- a/src/services/mclassService.ts
+++ b/src/services/mclassService.ts
@@ -52,6 +52,25 @@ export async function getMClassById(em: EntityManager, id: number) {
   return plainToInstance(MClassDetailDto, mclass, { excludeExtraneousValues: true });
 }
 
+export async function deleteMClassById(em: EntityManager, id: number) {
+  const repo = em.getRepository(MClass);
+
+  const mclass = await repo.findOne({
+    $and: [
+      { id: id },
+      { isDelete: false }
+    ]}
+  );
+  if (!mclass) {
+    throw new NotFoundError();
+  }
+
+  mclass.isDelete = true;
+  await em.flush();
+
+  return mclass.id;
+}
+
 function validateDate(deadline: Date, startAt: Date, endAt: Date) {
   const now = new Date();
   // 마감 시간 및 시작 시간은 현재 시간보다 커야 함

--- a/src/tests/integration/mclasses-id-delete.test.ts
+++ b/src/tests/integration/mclasses-id-delete.test.ts
@@ -1,0 +1,95 @@
+import request from 'supertest';
+
+import { DI, start } from '../../index';
+import app from '../../app';
+import { ErrorMessages } from '../../constants';
+
+const API = '/api/mclasses/';
+
+describe('M클래스 삭제 API DELETE /api/mclasses/:id 통합 테스트', () => {
+  let adminToken: string;
+  let mclassId: number
+
+  beforeAll(async () => {
+    await start;
+    await DI.orm.getSchemaGenerator().refreshDatabase();
+
+    const adminUserData = {
+        username: 'admin',
+        password: 'password',
+        name: 'admin',
+        email: 'admin@example.com',
+        isAdmin: true
+    };
+    await request(app).post('/api/users/signup').send(adminUserData);
+    const LoginResult = await request(app).post('/api/users/login').send(adminUserData);
+    adminToken = LoginResult.body.accessToken;
+
+    const mclassData = {
+      title: 'test class',
+      description: 'class description',
+      maxPeople: 10,
+      deadline: new Date(Date.now() + 1000 * 60).toISOString(),
+      startAt: new Date(Date.now() + 1000 * 60 * 60).toISOString(),
+      endAt: new Date(Date.now() + 1000 * 60 * 60 * 2).toISOString(),
+      fee: 100
+    };
+    const createResult = await request(app).post(API).set('Authorization', `Bearer ${adminToken}`).send(mclassData);
+    mclassId = createResult.body.id;
+  });
+
+  afterAll(async () => {
+    await DI.orm.close(true);
+    DI.server.close();
+  });
+
+  beforeEach(async () => {
+    DI.em = DI.orm.em.fork();
+  });
+
+  it('M클래스 삭제 성공', async () => {
+    const result = await request(app).delete(API + mclassId).set('Authorization', `Bearer ${adminToken}`);
+
+    expect(result.status).toBe(200);
+    expect(result.body).toEqual({ id: mclassId });
+  })
+
+  it('JWT가 없는 경우 실패', async () => {
+    const result = await request(app).delete(API + mclassId);
+
+    expect(result.status).toBe(401);
+    expect(result.body.message).toBe(ErrorMessages.UNAUTHORIZED);
+  });
+
+  it('관리자가 아닌 유저가 요청한 경우 실패', async () => {
+    const commonUserData = {
+      username: 'common',
+      password: 'password',
+      name: 'common',
+      email: 'common@example.com',
+      isAdmin: false
+    };
+    await request(app).post('/api/users/signup').send(commonUserData);
+    const LoginResult = await request(app).post('/api/users/login').send(commonUserData);
+    const commomToken = LoginResult.body.accessToken;
+
+    const result = await request(app).delete(API + mclassId).set('Authorization', `Bearer ${commomToken}`);
+
+    expect(result.status).toBe(403);
+    expect(result.body.message).toBe(ErrorMessages.FORBIDDEN);
+  })
+
+  it('존재하지 않는 id인 경우 실패', async () => {
+    const result = await request(app).delete(API + '100').set('Authorization', `Bearer ${adminToken}`);
+
+    expect(result.status).toBe(404);
+    expect(result.body.message).toBe(ErrorMessages.NOT_FOUND);
+  });
+
+  it('이미 삭제한 id인 경우 실패', async () => {
+    const result = await request(app).delete(API + mclassId).set('Authorization', `Bearer ${adminToken}`);
+
+    expect(result.status).toBe(404);
+    expect(result.body.message).toBe(ErrorMessages.NOT_FOUND);
+  });
+});

--- a/src/tests/unit/mclassService.test.ts
+++ b/src/tests/unit/mclassService.test.ts
@@ -1,6 +1,6 @@
 import { EntityManager, EntityRepository, QueryOrder } from '@mikro-orm/postgresql';
 
-import { createMClass, getMClassList, getMClassById } from '../../services/mclassService';
+import { createMClass, getMClassList, getMClassById, deleteMClassById } from '../../services/mclassService';
 import { MClass } from '../../entities';
 import { ErrorMessages } from '../../constants';
 import { NotFoundError } from '../../errors';
@@ -194,4 +194,35 @@ describe('getMClassById unit test - M클래스 상세 조회 관련 서비스 �
 
     await expect(getMClassById(em, 1)).rejects.toThrow(NotFoundError);
   });
-})
+});
+
+describe('deleteMclassById unit test - M클래스 삭제 관련 서비스 유닛 테스트', () => {
+  let em: EntityManager;
+  let mclassRepo: EntityRepository<MClass>;
+
+  beforeEach(() => {
+    mclassRepo = {
+      findOne: jest.fn()
+    } as unknown as EntityRepository<MClass>;
+
+    em = {
+      getRepository: jest.fn(() => mclassRepo),
+      flush: jest.fn()
+    } as unknown as EntityManager;
+  });
+
+  it('mclass 삭제 성공', async () => {
+    const mclassData = { id: 1 };
+    (mclassRepo.findOne as jest.Mock).mockResolvedValue(mclassData);
+
+    const result = await deleteMClassById(em, mclassData.id);
+
+    expect(result).toBe(mclassData.id);
+  });
+
+  it('존재하지 않거나 이미 삭제된 id인 경우 실패', async () => {
+    (mclassRepo.findOne as jest.Mock).mockResolvedValue(null);
+
+    await expect(deleteMClassById(em, 1)).rejects.toThrow(NotFoundError);
+  });
+});


### PR DESCRIPTION
## M클래스 삭제 API 작성
### M클래스 삭제 로직
* id에 해당하는 M클래스 삭제
* 실제 DB에서 row를 삭제하는 것이 아니라 isDelete true로 변경
* JWT 검증하여 isAdmin이 true인 사용자(관리자)만 가능, 그 외 사용자 예외 처리
* 유효성 검사 실패할 경우 예외 처리
* 존재하지 않는 id거나 이미 삭제된 M클래스인 경우 예외 처리
* 그 외 성공

### MClass Entity 필드 추가
* isDelete: 삭제 여부, default false
  * true: 삭제됨, false: 삭제되지 않음