### PR TITLE
조회 쿼리에 isDelete 조건 추가

### DIFF
--- a/src/services/mclassService.ts
+++ b/src/services/mclassService.ts
@@ -35,7 +35,7 @@ export async function createMClass(em: EntityManager, data: CreateMClassDto, req
 export async function getMClassList(em: EntityManager, data: GetMClassListQueryDto) {
   const repo = em.getRepository(MClass);
 
-  const where = data.last ? { id: { $lt: data.last }} : {};
+  const where = data.last ? { $and: [{ id: { $lt: data.last }}, { isDelete: false }] } : { isDelete: false };
   const mclassList = await repo.find(where, { orderBy: { id: QueryOrder.DESC }, limit: data.limit });
 
   return plainToInstance(MClassListItemDto, mclassList, { excludeExtraneousValues: true });
@@ -44,7 +44,7 @@ export async function getMClassList(em: EntityManager, data: GetMClassListQueryD
 export async function getMClassById(em: EntityManager, id: number) {
   const repo = em.getRepository(MClass);
 
-  const mclass = await repo.findOne({ id: id });
+  const mclass = await repo.findOne({ $and: [{ id: id }, { isDelete: false }] });
   if (!mclass) {
     throw new NotFoundError();
   }

--- a/src/tests/integration/mclasses-get.test.ts
+++ b/src/tests/integration/mclasses-get.test.ts
@@ -37,8 +37,10 @@ describe('M클래스 목록 조회 API GET /api/mclasses 통합 테스트', () =
     };
     const mclassListData = new Array(mclassListLength).fill(0).map(() => ({ ...mclassData }));
     for (const data of mclassListData) {
-      await request(app).post(API).set('Authorization', `Bearer ${adminToken}`).send(data)
+      await request(app).post(API).set('Authorization', `Bearer ${adminToken}`).send(data);
     }
+
+    await request(app).delete(API + '/2').set('Authorization', `Bearer ${adminToken}`);
   });
 
   afterAll(async () => {
@@ -85,6 +87,18 @@ describe('M클래스 목록 조회 API GET /api/mclasses 통합 테스트', () =
     expect(result.body.list.length).toBe(limit);
     expect(result.body.list[0].id).toBe(mclassListLength);
   });
+
+  it('삭제된 M클래스는 제외하고 목록 조회 성공', async () => {
+    const limit = 5;
+    const last = 7;
+    
+    const result = await request(app).get(API).query({ limit: limit, last: last });
+
+    expect(result.status).toBe(200);
+    expect(result.body.list).toBeInstanceOf(Array);
+    expect(result.body.list.length).toBe(limit);
+    expect(result.body.list[result.body.list.length - 1].id).toBe(1);
+  })
 
   it('limit가 number가 아닐 경우 실패', async () => {
     const limit = 'wrong';

--- a/src/tests/integration/mclasses-id-get.test.ts
+++ b/src/tests/integration/mclasses-id-get.test.ts
@@ -7,6 +7,8 @@ import { ErrorMessages } from '../../constants';
 const API = '/api/mclasses/';
 
 describe('M클래스 상세 조회 API GET /api/mclasses/:id 통합 테스트', () => {
+  let adminToken: string;
+
   const mclassData = {
     title: 'test class',
     description: 'class description',
@@ -30,7 +32,7 @@ describe('M클래스 상세 조회 API GET /api/mclasses/:id 통합 테스트', 
     };
     await request(app).post('/api/users/signup').send(adminUserData);
     const LoginResult = await request(app).post('/api/users/login').send(adminUserData);
-    const adminToken = LoginResult.body.accessToken;
+    adminToken = LoginResult.body.accessToken;
 
     await request(app).post(API).set('Authorization', `Bearer ${adminToken}`).send(mclassData);
   });
@@ -58,6 +60,15 @@ describe('M클래스 상세 조회 API GET /api/mclasses/:id 통합 테스트', 
       fee: mclassData.fee
     });
   });
+
+  it('삭제된 id로 조회할 경우 실패', async () => {
+    await request(app).delete(API + '1').set('Authorization', `Bearer ${adminToken}`);
+
+    const result = await request(app).get(API + '1');
+
+    expect(result.status).toBe(404);
+    expect(result.body.message).toBe(ErrorMessages.NOT_FOUND);
+  })
 
   it('존재하지 않는 id로 조회할 경우 실패', async () => {
     const result = await request(app).get(API + '100');

--- a/src/tests/unit/mclassService.test.ts
+++ b/src/tests/unit/mclassService.test.ts
@@ -133,7 +133,14 @@ describe('getMClassList unit test - M클래스 목록 조회 관련 서비스 �
 
     await getMClassList(em, input);
 
-    expect(mclassRepo.find).toHaveBeenCalledWith({ id: { $lt: input.last } },{ orderBy: { id: QueryOrder.DESC },limit: input.limit });
+    
+    expect(mclassRepo.find).toHaveBeenCalledWith(
+      { $and: [
+        { id: { $lt: input.last }},
+        { isDelete: false }
+      ] },
+      { orderBy: { id: QueryOrder.DESC }, limit: input.limit }
+    );
   });
 
   it('last가 없는 경우 where 없이 mclass 목록 조회 성공', async () => {
@@ -144,7 +151,7 @@ describe('getMClassList unit test - M클래스 목록 조회 관련 서비스 �
 
     await getMClassList(em, input);
 
-    expect(mclassRepo.find).toHaveBeenCalledWith({},{ orderBy: { id: QueryOrder.DESC },limit: input.limit });
+    expect(mclassRepo.find).toHaveBeenCalledWith({ isDelete: false },{ orderBy: { id: QueryOrder.DESC }, limit: input.limit });
   })
 });
 
@@ -175,8 +182,9 @@ describe('getMClassById unit test - M클래스 상세 조회 관련 서비스 �
     };
     (mclassRepo.findOne as jest.Mock).mockResolvedValue(mclassData);
 
-    const result = await getMClassById(em, 1);
+    const result = await getMClassById(em, mclassData.id);
 
+    expect(mclassRepo.findOne).toHaveBeenCalledWith({ $and: [{ id: mclassData.id }, { isDelete: false }] });
     expect(result).toEqual({
       id: mclassData.id,
       title: mclassData.title,


### PR DESCRIPTION
* MClass 엔티티에 논리적 삭제 여부를 저장하는 필드 isDelete의 추가로 인한 코드 변경
* MClass 조회하는 쿼리 조건에 isDelete = false 추가