### PR TITLE
테스트 코드 및 서비스 코드 개선

### DIFF
--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -21,7 +21,7 @@ export const login = async (req: Request, res: Response, next: NextFunction) => 
     const em = RequestContext.getEntityManager() as EntityManager;
     const accessToken = await loginUser(em, req.body);
 
-    res.status(201).json(accessToken);
+    res.status(201).json({ accessToken });
   }
   catch (err: any) {
     next(err);

--- a/src/services/mclassService.ts
+++ b/src/services/mclassService.ts
@@ -35,8 +35,10 @@ export async function createMClass(em: EntityManager, data: CreateMClassDto, req
 export async function getMClassList(em: EntityManager, data: GetListQueryDto) {
   const repo = em.getRepository(MClass);
 
-  const where = data.last ? { $and: [{ id: { $lt: data.last }}, { isDelete: false }] } : { isDelete: false };
-  const mclassList = await repo.find(where, { orderBy: { id: QueryOrder.DESC }, limit: data.limit });
+  const mclassList = await repo.find(
+    { ...(data.last ? {id: { $lt: data.last }} : {}), isDelete: false },
+    { orderBy: { id: QueryOrder.DESC }, limit: data.limit }
+  );
 
   return plainToInstance(MClassListItemDto, mclassList, { excludeExtraneousValues: true });
 }
@@ -44,7 +46,7 @@ export async function getMClassList(em: EntityManager, data: GetListQueryDto) {
 export async function getMClassById(em: EntityManager, id: number) {
   const repo = em.getRepository(MClass);
 
-  const mclass = await repo.findOne({ $and: [{ id: id }, { isDelete: false }] });
+  const mclass = await repo.findOne({ id: id, isDelete: false });
   if (!mclass) {
     throw new NotFoundError();
   }
@@ -56,12 +58,7 @@ export async function deleteMClassById(em: EntityManager, id: number) {
   const mclassRepo = em.getRepository(MClass);
   const appRepo = em.getRepository(Application);
 
-  const mclass = await mclassRepo.findOne({
-    $and: [
-      { id: id },
-      { isDelete: false }
-    ]}
-  );
+  const mclass = await mclassRepo.findOne({ id: id, isDelete: false });
   if (!mclass) {
     throw new NotFoundError();
   }
@@ -85,7 +82,7 @@ export async function applyToMClass(em: EntityManager, id: number, requestUser: 
   try {
     const mclass = await em.findOne(
       MClass,
-      { $and: [{ id: id }, { isDelete: false }] },
+      { id: id, isDelete: false },
       { lockMode: LockMode.PESSIMISTIC_WRITE }
     );
     if (!mclass) {

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -59,8 +59,13 @@ async function checkUserCreateData(repo: EntityRepository<User>, username: strin
   );
 
   if (existingUser) {
+    // 이미 존재하는 username
     if (existingUser.username === username) throw new ConflictError(ErrorMessages.EXISTING_USERNAME);
+
+    // 이미 존재하는 email
     if (existingUser.email === email) throw new ConflictError(ErrorMessages.EXISTING_EMAIL);
+
+    // 이미 존재하는 phone
     if (phone && existingUser.phone === phone) throw new ConflictError(ErrorMessages.EXISTING_PHONE);
   }
 }

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -46,7 +46,7 @@ export async function loginUser(em: EntityManager, data: LoginDto) {
     ENV.JWT.SECRET_KEY
   );
 
-  return { accessToken };
+  return accessToken;
 }
 
 async function checkUserCreateData(repo: EntityRepository<User>, username: string, email: string, phone?: string) {

--- a/src/tests/integration/login.test.ts
+++ b/src/tests/integration/login.test.ts
@@ -2,7 +2,6 @@ import request from 'supertest';
 
 import { DI, start } from '../../index';
 import app from '../../app';
-import { User } from '../../entities';
 import { ErrorMessages } from '../../constants';
 
 const API = '/api/users/login';
@@ -18,6 +17,9 @@ describe('로그인 API POST /api/users/login 통합 테스트', () => {
   beforeAll(async () => {
     await start;
     await DI.orm.getSchemaGenerator().refreshDatabase();
+
+    // 회원가입
+    await request(app).post('/api/users/signup').send(existingData);
   });
 
   afterAll(async () => {
@@ -27,16 +29,13 @@ describe('로그인 API POST /api/users/login 통합 테스트', () => {
 
   beforeEach(async () => {
     DI.em = DI.orm.em.fork();
-    await DI.em.nativeDelete(User, {});
-
-    await request(app).post('/api/users/signup').send(existingData);
   });
 
   it('로그인 성공', async () => {
     const result = await request(app).post(API).send(existingData);
 
     expect(result.status).toBe(201);
-    expect(result.body).toHaveProperty('accessToken');
+    expect(result.body).toEqual({ accessToken: expect.any(String) });
   });
 
   it('존재하지 않는 아이디로 로그인 시 실패', async () => {

--- a/src/tests/integration/mclasses-get.test.ts
+++ b/src/tests/integration/mclasses-get.test.ts
@@ -10,36 +10,40 @@ describe('M클래스 목록 조회 API GET /api/mclasses 통합 테스트', () =
   let adminToken: string;
 
   const mclassListLength = 15;
-  const adminUserData = {
-    username: 'admin',
-    password: 'password',
-    name: 'admin',
-    email: 'admin@example.com',
-    isAdmin: true
+  const mclassData = {
+    title: 'test class',
+    description: 'class description',
+    maxPeople: 10,
+    deadline: new Date(Date.now() + 1000 * 60).toISOString(),
+    startAt: new Date(Date.now() + 1000 * 60 * 60).toISOString(),
+    endAt: new Date(Date.now() + 1000 * 60 * 60 * 2).toISOString(),
+    fee: 100
   };
-
+  
   beforeAll(async () => {
     await start;
     await DI.orm.getSchemaGenerator().refreshDatabase();
 
+    // 1. 회원가입 및 로그인하여 토큰 획득
+    const adminUserData = {
+      username: 'admin',
+      password: 'password',
+      name: 'admin',
+      email: 'admin@example.com',
+      isAdmin: true
+    };
     await request(app).post('/api/users/signup').send(adminUserData);
     const LoginResult = await request(app).post('/api/users/login').send(adminUserData);
+
     adminToken = LoginResult.body.accessToken;
 
-    const mclassData = {
-      title: 'test class',
-      description: 'class description',
-      maxPeople: 10,
-      deadline: new Date(Date.now() + 1000 * 60).toISOString(),
-      startAt: new Date(Date.now() + 1000 * 60 * 60).toISOString(),
-      endAt: new Date(Date.now() + 1000 * 60 * 60 * 2).toISOString(),
-      fee: 100
-    };
+    // 2. M클래스 mclassListLength 개 생성
     const mclassListData = new Array(mclassListLength).fill(0).map(() => ({ ...mclassData }));
     for (const data of mclassListData) {
       await request(app).post(API).set('Authorization', `Bearer ${adminToken}`).send(data);
     }
 
+    // 3. id가 2인 M클래스 삭제
     await request(app).delete(API + '/2').set('Authorization', `Bearer ${adminToken}`);
   });
 
@@ -61,7 +65,14 @@ describe('M클래스 목록 조회 API GET /api/mclasses 통합 테스트', () =
     expect(result.status).toBe(200);
     expect(result.body.list).toBeInstanceOf(Array);
     expect(result.body.list.length).toBe(limit);
-    expect(result.body.list[0].id).toBe(last - 1);
+    expect(result.body.list[0]).toEqual({
+      id: last - 1,
+      title: mclassData.title,
+      maxPeople: mclassData.maxPeople,
+      deadline: mclassData.deadline,
+      startAt: mclassData.startAt,
+      endAt: mclassData.endAt
+    });
   });
 
   it(`limit가 없는 경우 M클래스 목록 ${DefaultLimits.MCLASS} 개 조회 성공`, async () => {
@@ -73,7 +84,14 @@ describe('M클래스 목록 조회 API GET /api/mclasses 통합 테스트', () =
     expect(result.status).toBe(200);
     expect(result.body.list).toBeInstanceOf(Array);
     expect(result.body.list.length).toBe(DefaultLimits.MCLASS);
-    expect(result.body.list[0].id).toBe(last - 1);
+    expect(result.body.list[0]).toEqual({
+      id: last - 1,
+      title: mclassData.title,
+      maxPeople: mclassData.maxPeople,
+      deadline: mclassData.deadline,
+      startAt: mclassData.startAt,
+      endAt: mclassData.endAt
+    });
   });
 
   it('last가 없는 경우 M클래스 목록 조회 성공', async () => {
@@ -85,7 +103,14 @@ describe('M클래스 목록 조회 API GET /api/mclasses 통합 테스트', () =
     expect(result.status).toBe(200);
     expect(result.body.list).toBeInstanceOf(Array);
     expect(result.body.list.length).toBe(limit);
-    expect(result.body.list[0].id).toBe(mclassListLength);
+    expect(result.body.list[0]).toEqual({
+      id: mclassListLength,
+      title: mclassData.title,
+      maxPeople: mclassData.maxPeople,
+      deadline: mclassData.deadline,
+      startAt: mclassData.startAt,
+      endAt: mclassData.endAt
+    });
   });
 
   it('삭제된 M클래스는 제외하고 목록 조회 성공', async () => {
@@ -97,7 +122,14 @@ describe('M클래스 목록 조회 API GET /api/mclasses 통합 테스트', () =
     expect(result.status).toBe(200);
     expect(result.body.list).toBeInstanceOf(Array);
     expect(result.body.list.length).toBe(limit);
-    expect(result.body.list[result.body.list.length - 1].id).toBe(1);
+    expect(result.body.list[result.body.list.length - 1]).toEqual({
+      id: 1,
+      title: mclassData.title,
+      maxPeople: mclassData.maxPeople,
+      deadline: mclassData.deadline,
+      startAt: mclassData.startAt,
+      endAt: mclassData.endAt
+    });
   })
 
   it('limit가 number가 아닐 경우 실패', async () => {

--- a/src/tests/integration/signup.test.ts
+++ b/src/tests/integration/signup.test.ts
@@ -35,9 +35,7 @@ describe('회원가입 API POST /api/usres/signup 통합 테스트', () => {
       isAdmin: false
     };
 
-    const result = await request(app)
-      .post(API)
-      .send(input);
+    const result = await request(app).post(API).send(input);
 
     expect(result.status).toBe(201);
     expect(result.body).toMatchObject({
@@ -45,7 +43,7 @@ describe('회원가입 API POST /api/usres/signup 통합 테스트', () => {
       name: input.name,
       email: input.email,
       phone: input.phone,
-      isAdmin: input.isAdmin,
+      isAdmin: input.isAdmin
     });
 
     // 비밀번호가 해시로 저장되었는지 확인
@@ -64,9 +62,7 @@ describe('회원가입 API POST /api/usres/signup 통합 테스트', () => {
       isAdmin: true
     };
 
-    const result = await request(app)
-      .post(API)
-      .send(input);
+    const result = await request(app).post(API).send(input);
 
     expect(result.status).toBe(201);
     expect(result.body.isAdmin).toBe(true);
@@ -81,77 +77,71 @@ describe('회원가입 API POST /api/usres/signup 통합 테스트', () => {
       phone: '010-1234-5678'
     };
 
-    const result = await request(app)
-      .post(API)
-      .send(input);
+    const result = await request(app).post(API).send(input);
 
     expect(result.status).toBe(201);
     expect(result.body.isAdmin).toBe(false);
   });
 
   it('phone이 주어지지 않은 경우 가입 성공', async () => {
-      const input = {
-        username: 'test',
-        password: 'password',
-        name: 'user',
-        email: 'test@example.com'
-      };
-  
-      const result = await request(app)
-      .post(API)
-      .send(input);
-  
-      expect(result.body.phone).toBe(undefined);
-    });
+    const input = {
+      username: 'test',
+      password: 'password',
+      name: 'user',
+      email: 'test@example.com'
+    };
 
-    it('username이 8자를 초과한 경우 가입 실패', async () => {
-      const input = {
-        username: '123456789',
-        password: 'password',
-        name: 'user',
-        email: 'test@example.com'
-      };
-  
-      const result = await request(app)
-      .post(API)
-      .send(input);
+    const result = await request(app).post(API).send(input);
 
-      expect(result.status).toBe(400);
-    })
+    expect(result.status).toBe(201);
+    expect(result.body.phone).toBe(undefined);
+  });
 
-    it('email 형식이 틀릴 경우 가입 실패', async () => {
-      const input = {
-        username: 'test',
-        password: 'password',
-        name: 'user',
-        email: 'test@example'
-      };
-  
-      const result = await request(app)
-      .post(API)
-      .send(input);
+  it('username이 8자를 초과한 경우 가입 실패', async () => {
+    const input = {
+      username: '123456789',
+      password: 'password',
+      name: 'user',
+      email: 'test@example.com'
+    };
 
-      expect(result.status).toBe(400);
-    })
+    const result = await request(app).post(API).send(input);
 
-    it('phone 형식이 틀릴 경우 가입 실패', async () => {
-      const input = {
-        username: 'test',
-        password: 'password',
-        name: 'user',
-        email: 'test@example.com',
-        phone: '0101234'
-      };
-  
-      const result = await request(app)
-      .post(API)
-      .send(input);
+    expect(result.status).toBe(400);
+    expect(result.body.message).toBe(ErrorMessages.VALIDATION_FAILED);
+  })
 
-      expect(result.status).toBe(400);
-    })
+  it('email 형식이 틀릴 경우 가입 실패', async () => {
+    const input = {
+      username: 'test',
+      password: 'password',
+      name: 'user',
+      email: 'test@example'
+    };
 
-    it('username이 중복인 경우 가입 실패', async () => {
-      const input = {
+    const result = await request(app).post(API).send(input);
+
+    expect(result.status).toBe(400);
+    expect(result.body.message).toBe(ErrorMessages.VALIDATION_FAILED);
+  })
+
+  it('phone 형식이 틀릴 경우 가입 실패', async () => {
+    const input = {
+      username: 'test',
+      password: 'password',
+      name: 'user',
+      email: 'test@example.com',
+      phone: '0101234'
+    };
+
+    const result = await request(app).post(API).send(input);
+
+    expect(result.status).toBe(400);
+    expect(result.body.message).toBe(ErrorMessages.VALIDATION_FAILED);
+  })
+
+  it('username이 중복인 경우 가입 실패', async () => {
+    const input = {
       username: 'test',
       password: 'password',
       name: 'user',
@@ -159,10 +149,8 @@ describe('회원가입 API POST /api/usres/signup 통합 테스트', () => {
       phone: '010-1234-5678'
     };
 
-    const result1 = await request(app)
-      .post(API)
-      .send(input);
-    
+    // 동일한 username으로 두 번 가입
+    const result1 = await request(app).post(API).send(input);
     expect(result1.status).toBe(201);
 
     const result2 = await request(app)
@@ -174,7 +162,7 @@ describe('회원가입 API POST /api/usres/signup 통합 테스트', () => {
   })
 
   it('email이 중복인 경우 가입 실패', async () => {
-      const input = {
+    const input = {
       username: 'test',
       password: 'password',
       name: 'user',
@@ -182,10 +170,8 @@ describe('회원가입 API POST /api/usres/signup 통합 테스트', () => {
       phone: '010-1234-5678'
     };
 
-    const result1 = await request(app)
-      .post(API)
-      .send(input);
-    
+    // 동일한 email로 두 번 가입
+    const result1 = await request(app).post(API).send(input);
     expect(result1.status).toBe(201);
 
     const result2 = await request(app)
@@ -197,7 +183,7 @@ describe('회원가입 API POST /api/usres/signup 통합 테스트', () => {
   })
 
   it('phone이 중복인 경우 가입 실패', async () => {
-      const input = {
+    const input = {
       username: 'test',
       password: 'password',
       name: 'user',
@@ -205,10 +191,8 @@ describe('회원가입 API POST /api/usres/signup 통합 테스트', () => {
       phone: '010-1234-5678'
     };
 
-    const result1 = await request(app)
-      .post(API)
-      .send(input);
-    
+    // 동일한 phone으로 두 번 가입
+    const result1 = await request(app).post(API).send(input);
     expect(result1.status).toBe(201);
 
     const result2 = await request(app)

--- a/src/tests/unit/applicationService.test.ts
+++ b/src/tests/unit/applicationService.test.ts
@@ -23,11 +23,11 @@ describe('getApplicationList unit test - 내 신청 내역 조회 관련 서비�
     await getMyApplicationList(em, input, requestUser);
 
     expect(appRepo.find).toHaveBeenCalledWith(
-      expect.objectContaining({
+      {
         user: requestUser.id,
         mclass: { id: { $lt: input.last }, isDelete: false }
-      }),
-      expect.anything()
+      },
+      expect.objectContaining({ limit: input.limit })
     );
   });
 
@@ -45,11 +45,8 @@ describe('getApplicationList unit test - 내 신청 내역 조회 관련 서비�
     await getMyApplicationList(em, input, requestUser);
 
     expect(appRepo.find).toHaveBeenCalledWith(
-      expect.objectContaining({
-        user: requestUser.id,
-        mclass: { isDelete: false }
-      }),
-      expect.anything()
+      { user: requestUser.id, mclass: { isDelete: false } },
+      expect.objectContaining({ limit: input.limit })
     );
   });
 });

--- a/src/tests/unit/mclassService.test.ts
+++ b/src/tests/unit/mclassService.test.ts
@@ -1,13 +1,13 @@
-import { EntityManager, EntityRepository, QueryOrder } from '@mikro-orm/postgresql';
+import { QueryOrder } from '@mikro-orm/postgresql';
 
 import { createMClass, getMClassList, getMClassById, deleteMClassById, applyToMClass } from '../../services/mclassService';
-import { MClass, Application } from '../../entities';
+import { MClass } from '../../entities';
 import { ErrorMessages } from '../../constants';
-import { ConflictError, NotFoundError } from '../../errors';
+import { ConflictError, NotFoundError, ValidationError } from '../../errors';
 
 describe('createMClass unit test - M클래스 생성 관련 서비스 유닛 테스트', () => {
-  let em: EntityManager;
-  let mclassRepo: EntityRepository<MClass>;
+  let em: any;
+  let mclassRepo: any;
 
   const requestUser = {
     id: 1,
@@ -16,15 +16,12 @@ describe('createMClass unit test - M클래스 생성 관련 서비스 유닛 테
   };
 
   beforeEach(() => {
-    mclassRepo = {
-      create: jest.fn()
-    } as unknown as EntityRepository<MClass>;
-
+    mclassRepo = { create: jest.fn() };
     em = {
       getReference: jest.fn(() => requestUser.id),
       getRepository: jest.fn(() => mclassRepo),
       flush: jest.fn()
-    } as unknown as EntityManager;
+    };
   });
 
   it('mclass 저장 성공', async () => {
@@ -63,7 +60,7 @@ describe('createMClass unit test - M클래스 생성 관련 서비스 유닛 테
       fee: 100
     };
 
-    await expect(createMClass(em, input, requestUser)).rejects.toThrow(ErrorMessages.WRONG_DATE);
+    await expect(createMClass(em, input, requestUser)).rejects.toThrow(new ValidationError(ErrorMessages.WRONG_DATE));
   });
 
   it('startAt이 과거인 경우 실패', async () => {
@@ -77,7 +74,7 @@ describe('createMClass unit test - M클래스 생성 관련 서비스 유닛 테
       fee: 100
     };
 
-    await expect(createMClass(em, input, requestUser)).rejects.toThrow(ErrorMessages.WRONG_DATE);
+    await expect(createMClass(em, input, requestUser)).rejects.toThrow(new ValidationError(ErrorMessages.WRONG_DATE));
   });
 
   it('startAt이 deadline보다 작은 경우 실패', async () => {
@@ -91,7 +88,7 @@ describe('createMClass unit test - M클래스 생성 관련 서비스 유닛 테
       fee: 100
     };
 
-    await expect(createMClass(em, input, requestUser)).rejects.toThrow(ErrorMessages.WRONG_DATE);
+    await expect(createMClass(em, input, requestUser)).rejects.toThrow(new ValidationError(ErrorMessages.WRONG_DATE));
   });
 
   it('endAt이 startAt보다 작은 경우 실패', async () => {
@@ -105,40 +102,29 @@ describe('createMClass unit test - M클래스 생성 관련 서비스 유닛 테
       fee: 100
     };
 
-    await expect(createMClass(em, input, requestUser)).rejects.toThrow(ErrorMessages.WRONG_DATE);
+    await expect(createMClass(em, input, requestUser)).rejects.toThrow(new ValidationError(ErrorMessages.WRONG_DATE));
   });
 });
 
 describe('getMClassList unit test - M클래스 목록 조회 관련 서비스 유닛 테스트', () => {
-  let em: EntityManager;
-  let mclassRepo: EntityRepository<MClass>;
-
-  const mclassListData = [{ id:1 }, { id: 2 }, { id: 3 }]
+  let em: any;
+  let mclassRepo: any;
 
   beforeEach(() => {
-    mclassRepo = {
-      find: jest.fn(() => mclassListData)
-    } as unknown as EntityRepository<MClass>;
-
-    em = {
-      getRepository: jest.fn(() => mclassRepo)
-    } as unknown as EntityManager;
+    mclassRepo = { find: jest.fn() };
+    em = { getRepository: jest.fn(() => mclassRepo) };
   });
 
   it('mclass 목록 조회 성공', async () => {
     const input = {
       limit: 10,
       last: 1
-    }
+    };
 
     await getMClassList(em, input);
-
     
     expect(mclassRepo.find).toHaveBeenCalledWith(
-      { $and: [
-        { id: { $lt: input.last }},
-        { isDelete: false }
-      ] },
+      { id: { $lt: input.last }, isDelete: false },
       { orderBy: { id: QueryOrder.DESC }, limit: input.limit }
     );
   });
@@ -147,7 +133,7 @@ describe('getMClassList unit test - M클래스 목록 조회 관련 서비스 �
     const input = {
       limit: 10,
       last: undefined
-    }
+    };
 
     await getMClassList(em, input);
 
@@ -156,17 +142,12 @@ describe('getMClassList unit test - M클래스 목록 조회 관련 서비스 �
 });
 
 describe('getMClassById unit test - M클래스 상세 조회 관련 서비스 유닛 테스트', () => {
-  let em: EntityManager;
-  let mclassRepo: EntityRepository<MClass>;
+  let em: any;
+  let mclassRepo: any;
 
   beforeEach(() => {
-    mclassRepo = {
-      findOne: jest.fn()
-    } as unknown as EntityRepository<MClass>;
-
-    em = {
-      getRepository: jest.fn(() => mclassRepo)
-    } as unknown as EntityManager;
+    mclassRepo = { findOne: jest.fn() };
+    em = { getRepository: jest.fn(() => mclassRepo) };
   });
 
   it('mclass 상세 조회 성공', async () => {
@@ -180,11 +161,11 @@ describe('getMClassById unit test - M클래스 상세 조회 관련 서비스 �
       endAt: new Date(),
       fee: 100
     };
-    (mclassRepo.findOne as jest.Mock).mockResolvedValue(mclassData);
+    mclassRepo.findOne.mockResolvedValue(mclassData);
 
     const result = await getMClassById(em, mclassData.id);
 
-    expect(mclassRepo.findOne).toHaveBeenCalledWith({ $and: [{ id: mclassData.id }, { isDelete: false }] });
+    expect(mclassRepo.findOne).toHaveBeenCalledWith({ id: mclassData.id, isDelete: false });
     expect(result).toEqual({
       id: mclassData.id,
       title: mclassData.title,
@@ -200,31 +181,27 @@ describe('getMClassById unit test - M클래스 상세 조회 관련 서비스 �
   it('존재하지 않는 id인 경우 실패', async () => {
     (mclassRepo.findOne as jest.Mock).mockResolvedValue(null);
 
-    await expect(getMClassById(em, 1)).rejects.toThrow(NotFoundError);
+    await expect(getMClassById(em, 1)).rejects.toThrow(new NotFoundError());
   });
 });
 
 describe('deleteMClassById unit test - M클래스 삭제 관련 서비스 유닛 테스트', () => {
-  let em: EntityManager;
-  let mclassRepo: EntityRepository<MClass>;
+  let em: any;
+  let mclassRepo: any;
   let appRepo: any;
 
   beforeEach(() => {
-    mclassRepo = {
-      findOne: jest.fn()
-    } as unknown as EntityRepository<MClass>;
-
+    mclassRepo = { findOne: jest.fn() };
     appRepo = { count: jest.fn() }
-
     em = {
       getRepository: jest.fn((entity) => entity === MClass ? mclassRepo : appRepo),
       flush: jest.fn()
-    } as unknown as EntityManager;
+    };
   });
 
   it('mclass 삭제 성공', async () => {
     const mclassData = { id: 1 };
-    (mclassRepo.findOne as jest.Mock).mockResolvedValue(mclassData);
+    mclassRepo.findOne.mockResolvedValue(mclassData);
     appRepo.count.mockResolvedValue(0);
 
     const result = await deleteMClassById(em, mclassData.id);
@@ -233,14 +210,14 @@ describe('deleteMClassById unit test - M클래스 삭제 관련 서비스 유닛
   });
 
   it('존재하지 않거나 이미 삭제된 id인 경우 실패', async () => {
-    (mclassRepo.findOne as jest.Mock).mockResolvedValue(null);
+    mclassRepo.findOne.mockResolvedValue(null);
 
-    await expect(deleteMClassById(em, 1)).rejects.toThrow(NotFoundError);
+    await expect(deleteMClassById(em, 1)).rejects.toThrow(new NotFoundError());
   });
 
   it('이미 신청한 사람이 있는 경우 실패', async () => {
     const mclassData = { id: 1 };
-    (mclassRepo.findOne as jest.Mock).mockResolvedValue(mclassData);
+    mclassRepo.findOne.mockResolvedValue(mclassData);
     appRepo.count.mockResolvedValue(1);
 
     await expect(deleteMClassById(em, mclassData.id)).rejects.toThrow(new ConflictError(ErrorMessages.MCLASS_HAS_APPLICATION));
@@ -263,7 +240,6 @@ describe('applyToMClass unit test - M클래스 신청 관련 서비스 유닛 �
       count: jest.fn(),
       findOne: jest.fn()
     };
-
     em = {
       getRepository: jest.fn(() => appRepo),
       getReference: jest.fn(),

--- a/src/tests/unit/userService.test.ts
+++ b/src/tests/unit/userService.test.ts
@@ -159,7 +159,7 @@ describe('loginUser unit test - 로그인 관련 서비스 유닛 테스트', ()
 
     const result = await loginUser(em, input);
 
-    expect(result.accessToken).toBe(mockToken);
+    expect(result).toBe(mockToken);
   });
 
   it('존재하지 않는 username 사용 시 에러', async () => {

--- a/src/tests/unit/userService.test.ts
+++ b/src/tests/unit/userService.test.ts
@@ -1,28 +1,26 @@
-import { EntityManager, EntityRepository } from '@mikro-orm/postgresql';
 import bcrypt from 'bcrypt';
 import jwt from 'jsonwebtoken';
 
 import { createUser, loginUser } from '../../services/userService';
-import { User } from '../../entities';
 import { ErrorMessages } from '../../constants';
+import { ConflictError, UnauthorizedError } from '../../errors';
 
 jest.mock('bcrypt');
 jest.mock('jsonwebtoken');
 
 describe('createUser unit test - 회원가입 관련 서비스 유닛 테스트', () => {
-  let em: EntityManager;
-  let userRepo: EntityRepository<User>;
+  let em: any;
+  let userRepo: any;
 
   beforeEach(() => {
     userRepo = {
       create: jest.fn(),
       findOne: jest.fn()
-    } as unknown as EntityRepository<User>;
-
+    };
     em = {
       getRepository: jest.fn(() => userRepo),
       flush: jest.fn()
-    } as unknown as EntityManager;
+    };
   });
 
   it('user 저장 성공', async () => {
@@ -101,9 +99,9 @@ describe('createUser unit test - 회원가입 관련 서비스 유닛 테스트'
       phone: '010-1234-5678'
     };
 
-    (userRepo.findOne as jest.Mock).mockResolvedValue({ username: input.username });
+    userRepo.findOne.mockResolvedValue({ username: input.username });
 
-    await expect(createUser(em, input)).rejects.toThrow(ErrorMessages.EXISTING_USERNAME);
+    await expect(createUser(em, input)).rejects.toThrow(new ConflictError(ErrorMessages.EXISTING_USERNAME));
   });
 
   it('email 중복 시 에러 발생', async () => {
@@ -114,9 +112,9 @@ describe('createUser unit test - 회원가입 관련 서비스 유닛 테스트'
       email: 'test@example.com'
     };
 
-    (userRepo.findOne as jest.Mock).mockResolvedValue({ email: input.email });
+    userRepo.findOne.mockResolvedValue({ email: input.email });
 
-    await expect(createUser(em, input)).rejects.toThrow(ErrorMessages.EXISTING_EMAIL);
+    await expect(createUser(em, input)).rejects.toThrow(new ConflictError(ErrorMessages.EXISTING_EMAIL));
   });
 
   it('phone 중복 시 에러 발생', async () => {
@@ -128,24 +126,19 @@ describe('createUser unit test - 회원가입 관련 서비스 유닛 테스트'
       phone: '010-1234-5678'
     };
 
-    (userRepo.findOne as jest.Mock).mockResolvedValue({ phone: input.phone });
+    userRepo.findOne.mockResolvedValue({ phone: input.phone });
 
-    await expect(createUser(em, input)).rejects.toThrow(ErrorMessages.EXISTING_PHONE);
+    await expect(createUser(em, input)).rejects.toThrow(new ConflictError(ErrorMessages.EXISTING_PHONE));
   });
 });
 
 describe('loginUser unit test - 로그인 관련 서비스 유닛 테스트', () => {
-  let em: EntityManager;
-  let userRepo: EntityRepository<User>;
+  let em: any;
+  let userRepo: any;
 
   beforeEach(() => {
-    userRepo = {
-      findOne: jest.fn()
-    } as unknown as EntityRepository<User>;
-
-    em = {
-      getRepository: jest.fn(() => userRepo)
-    } as unknown as EntityManager;
+    userRepo = { findOne: jest.fn() }
+    em = { getRepository: jest.fn(() => userRepo) }
   });
 
   it('JWT 토큰 발급 성공', async () => {
@@ -160,7 +153,7 @@ describe('loginUser unit test - 로그인 관련 서비스 유닛 테스트', ()
     };
     const mockToken = 'access token';
 
-    (userRepo.findOne as jest.Mock).mockResolvedValue(mockUser);
+    userRepo.findOne.mockResolvedValue(mockUser);
     (bcrypt.compare as jest.Mock).mockResolvedValue(true);
     (jwt.sign as jest.Mock).mockReturnValue(mockToken);
 
@@ -175,9 +168,9 @@ describe('loginUser unit test - 로그인 관련 서비스 유닛 테스트', ()
       password: 'password'
     };
 
-    (userRepo.findOne as jest.Mock).mockResolvedValue(null);
+    userRepo.findOne.mockResolvedValue(null);
 
-    await expect(loginUser(em, input)).rejects.toThrow(ErrorMessages.LOGIN_FAILED);
+    await expect(loginUser(em, input)).rejects.toThrow(new UnauthorizedError(ErrorMessages.LOGIN_FAILED));
   });
 
   it('password 틀릴 경우 에러', async () => {
@@ -191,9 +184,9 @@ describe('loginUser unit test - 로그인 관련 서비스 유닛 테스트', ()
       password: 'password'
     };
 
-    (userRepo.findOne as jest.Mock).mockResolvedValue(mockUser);
+    userRepo.findOne.mockResolvedValue(mockUser);
     (bcrypt.compare as jest.Mock).mockResolvedValue(false);
 
-    await expect(loginUser(em, input)).rejects.toThrow(ErrorMessages.LOGIN_FAILED);
+    await expect(loginUser(em, input)).rejects.toThrow(new UnauthorizedError(ErrorMessages.LOGIN_FAILED));
   });
 });


### PR DESCRIPTION
## 테스트 코드 및 서비스 코드 개선
### 테스트 코드
- 주석 작성
- 유닛 테스트에서 예외 테스트 시 에러 타입과 메세지 동시에 검증하도록 수정
- 유닛 테스트에서 코드 간결화를 위해 모킹 시 any 타입 사용
- 응답 객체 비교 케이스 추가 및 강화
- 테스트 세팅 방식 변경

### 서비스 코드
- 주석 작성
- 쿼리 시에 $and 삭제하여 코드 간결화
- 로그인 API 서비스 함수(loginUser) 리턴 타입 변경
  - 객체에서 토큰 문자열만 리턴하도록 변경
  - 그로 인한 컨트롤러 코드 변경