### PR TITLE
DTO 기반으로 응답하도록 변경

### DIFF
--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -8,8 +8,7 @@ export const signup = async (req: Request, res: Response, next: NextFunction) =>
     const em = RequestContext.getEntityManager() as EntityManager;
     const user = await createUser(em, req.body);
 
-    const { password, ...newUser } = user;
-    res.status(201).json(newUser);
+    return res.status(201).json(user);
   }
   catch (err: any) {
     next(err);
@@ -21,7 +20,7 @@ export const login = async (req: Request, res: Response, next: NextFunction) => 
     const em = RequestContext.getEntityManager() as EntityManager;
     const accessToken = await loginUser(em, req.body);
 
-    res.status(201).json({ accessToken });
+    return res.status(201).json({ accessToken });
   }
   catch (err: any) {
     next(err);

--- a/src/dtos/CreateMclassResponseDto.ts
+++ b/src/dtos/CreateMclassResponseDto.ts
@@ -1,0 +1,31 @@
+import { Expose, Transform } from "class-transformer";
+
+export class CreateMClassResponseDto {
+    @Expose()
+    id: number;
+
+    @Expose()
+    title: string;
+
+    @Expose()
+    @Transform(({ value }) => value ?? null)
+    description: string | null;
+
+    @Expose()
+    maxPeople: number;
+
+    @Expose()
+    deadline: Date;
+    
+    @Expose()
+    startAt: Date;
+    
+    @Expose()
+    endAt: Date;
+    
+    @Expose()
+    fee: number;
+
+    @Expose()
+    createdAt: Date;
+}

--- a/src/dtos/CreateUserResponseDto.ts
+++ b/src/dtos/CreateUserResponseDto.ts
@@ -1,0 +1,25 @@
+import { Expose, Transform } from "class-transformer";
+
+export class CreateUserResponseDto {
+    @Expose()
+    id: number;
+
+    @Expose()
+    username: string;
+
+    @Expose()
+    name: string;
+
+    @Expose()
+    email: string;
+
+    @Expose()
+    @Transform(({ value }) => value ?? null)
+    phone: string | null;
+
+    @Expose()
+    isAdmin: boolean;
+
+    @Expose()
+    createdAt: Date;
+}

--- a/src/dtos/index.ts
+++ b/src/dtos/index.ts
@@ -7,3 +7,5 @@ export * from './GetListQueryDto';
 export * from './MClassDetailDto';
 export * from './IdParamDto';
 export * from './ApplicationListItemDto';
+export * from './CreateUserResponseDto';
+export * from './CreateMclassResponseDto';

--- a/src/services/mclassService.ts
+++ b/src/services/mclassService.ts
@@ -1,7 +1,7 @@
 import { EntityManager, EntityRepository, LockMode, QueryOrder } from '@mikro-orm/postgresql';
 import { plainToInstance } from 'class-transformer';
 
-import { CreateMClassDto, UserPayload, MClassListItemDto, GetListQueryDto, MClassDetailDto } from '../dtos';
+import { CreateMClassDto, UserPayload, MClassListItemDto, GetListQueryDto, MClassDetailDto, CreateMClassResponseDto } from '../dtos';
 import { User, MClass, Application } from '../entities';
 import { ErrorMessages } from '../constants';
 import { ValidationError, NotFoundError, ConflictError } from '../errors';
@@ -29,7 +29,7 @@ export async function createMClass(em: EntityManager, data: CreateMClassDto, req
   repo.create(mclass);
   await em.flush();
 
-  return mclass;
+  return plainToInstance(CreateMClassResponseDto, mclass, { excludeExtraneousValues: true });
 }
 
 export async function getMClassList(em: EntityManager, data: GetListQueryDto) {

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -3,10 +3,11 @@ import bcrypt from 'bcrypt';
 import jwt from 'jsonwebtoken';
 
 import { User } from '../entities';
-import { CreateUserDto, LoginDto } from '../dtos';
+import { CreateUserDto, CreateUserResponseDto, LoginDto } from '../dtos';
 import { ErrorMessages } from '../constants';
 import { ENV } from '../config';
 import { UnauthorizedError, ConflictError } from '../errors';
+import { plainToInstance } from 'class-transformer';
 
 export async function createUser(em: EntityManager, data: CreateUserDto) {
   const repo = em.getRepository(User);
@@ -22,10 +23,9 @@ export async function createUser(em: EntityManager, data: CreateUserDto) {
   user.isAdmin = data.isAdmin ?? false;
 
   repo.create(user);
-    
   await em.flush();
 
-  return user;
+  return plainToInstance(CreateUserResponseDto, user, { excludeExtraneousValues: true });
 }
 
 export async function loginUser(em: EntityManager, data: LoginDto) {

--- a/src/tests/integration/mclasses-post.test.ts
+++ b/src/tests/integration/mclasses-post.test.ts
@@ -53,7 +53,8 @@ describe('M클래스 생성 API POST /api/mclasses 통합 테스트', () => {
     const result = await request(app).post(API).set('Authorization', adminToken).send(input)
 
     expect(result.status).toBe(201);
-    expect(result.body).toMatchObject({
+    expect(result.body).toEqual({
+      id: result.body.id,
       title: input.title,
       description: input.description,
       maxPeople: input.maxPeople,
@@ -61,7 +62,33 @@ describe('M클래스 생성 API POST /api/mclasses 통합 테스트', () => {
       startAt: input.startAt,
       endAt: input.endAt,
       fee: input.fee,
-      createdUser: requestUserId
+      createdAt: result.body.createdAt
+    });
+  });
+
+  it('description이 없는 경우 M클래스 생성 성공', async () => {
+    const input = {
+      title: 'test class',
+      maxPeople: 10,
+      deadline: new Date(Date.now() + 1000 * 60).toISOString(),
+      startAt: new Date(Date.now() + 1000 * 60 * 60).toISOString(),
+      endAt: new Date(Date.now() + 1000 * 60 * 60 * 2).toISOString(),
+      fee: 100
+    };
+
+    const result = await request(app).post(API).set('Authorization', adminToken).send(input)
+
+    expect(result.status).toBe(201);
+    expect(result.body).toEqual({
+      id: result.body.id,
+      title: input.title,
+      description: null,
+      maxPeople: input.maxPeople,
+      deadline: input.deadline,
+      startAt: input.startAt,
+      endAt: input.endAt,
+      fee: input.fee,
+      createdAt: result.body.createdAt
     });
   });
 

--- a/src/tests/integration/signup.test.ts
+++ b/src/tests/integration/signup.test.ts
@@ -38,12 +38,14 @@ describe('회원가입 API POST /api/usres/signup 통합 테스트', () => {
     const result = await request(app).post(API).send(input);
 
     expect(result.status).toBe(201);
-    expect(result.body).toMatchObject({
+    expect(result.body).toEqual({
+      id: result.body.id,
       username: input.username,
       name: input.name,
       email: input.email,
       phone: input.phone,
-      isAdmin: input.isAdmin
+      isAdmin: input.isAdmin,
+      createdAt: result.body.createdAt
     });
 
     // 비밀번호가 해시로 저장되었는지 확인
@@ -65,7 +67,15 @@ describe('회원가입 API POST /api/usres/signup 통합 테스트', () => {
     const result = await request(app).post(API).send(input);
 
     expect(result.status).toBe(201);
-    expect(result.body.isAdmin).toBe(true);
+    expect(result.body).toEqual({
+      id: result.body.id,
+      username: input.username,
+      name: input.name,
+      email: input.email,
+      phone: input.phone,
+      isAdmin: input.isAdmin,
+      createdAt: result.body.createdAt
+    });
   })
 
   it('isAdmin이 주어지지 않은 경우 일반 유저로 가입 성공', async () => {
@@ -80,7 +90,15 @@ describe('회원가입 API POST /api/usres/signup 통합 테스트', () => {
     const result = await request(app).post(API).send(input);
 
     expect(result.status).toBe(201);
-    expect(result.body.isAdmin).toBe(false);
+    expect(result.body).toEqual({
+      id: result.body.id,
+      username: input.username,
+      name: input.name,
+      email: input.email,
+      phone: input.phone,
+      isAdmin: false,
+      createdAt: result.body.createdAt
+    });
   });
 
   it('phone이 주어지지 않은 경우 가입 성공', async () => {
@@ -94,7 +112,15 @@ describe('회원가입 API POST /api/usres/signup 통합 테스트', () => {
     const result = await request(app).post(API).send(input);
 
     expect(result.status).toBe(201);
-    expect(result.body.phone).toBe(undefined);
+    expect(result.body).toEqual({
+      id: result.body.id,
+      username: input.username,
+      name: input.name,
+      email: input.email,
+      phone: null,
+      isAdmin: false,
+      createdAt: result.body.createdAt
+    });
   });
 
   it('username이 8자를 초과한 경우 가입 실패', async () => {

--- a/src/tests/unit/mclassService.test.ts
+++ b/src/tests/unit/mclassService.test.ts
@@ -37,7 +37,8 @@ describe('createMClass unit test - M클래스 생성 관련 서비스 유닛 테
 
     const result = await createMClass(em, input, requestUser);
 
-    expect(result).toMatchObject({
+    expect(result).toEqual({
+      id: result.id,
       title: input.title,
       description: input.description,
       maxPeople: input.maxPeople,
@@ -45,7 +46,32 @@ describe('createMClass unit test - M클래스 생성 관련 서비스 유닛 테
       startAt: new Date(input.startAt),
       endAt: new Date(input.endAt),
       fee: input.fee,
-      createdUser: requestUser.id
+      createdAt: result.createdAt
+    });
+  });
+
+  it('description이 없는 경우 mclass 저장 성공', async () => {
+    const input = {
+      title: 'test class',
+      maxPeople: 10,
+      deadline: new Date(Date.now() + 1000 * 60).toISOString(),
+      startAt: new Date(Date.now() + 1000 * 60 * 60).toISOString(),
+      endAt: new Date(Date.now() + 1000 * 60 * 60 * 2).toISOString(),
+      fee: 100
+    };
+
+    const result = await createMClass(em, input, requestUser);
+
+    expect(result).toEqual({
+      id: result.id,
+      title: input.title,
+      description: null,
+      maxPeople: input.maxPeople,
+      deadline: new Date(input.deadline),
+      startAt: new Date(input.startAt),
+      endAt: new Date(input.endAt),
+      fee: input.fee,
+      createdAt: result.createdAt
     });
   });
 

--- a/src/tests/unit/userService.test.ts
+++ b/src/tests/unit/userService.test.ts
@@ -38,13 +38,14 @@ describe('createUser unit test - 회원가입 관련 서비스 유닛 테스트'
 
     const result = await createUser(em, input);
 
-    expect(result).toMatchObject({
+    expect(result).toEqual({
+      id: result.id,
       username: input.username,
-      password: hashedPassword,
       name: input.name,
       email: input.email,
       phone: input.phone,
       isAdmin: input.isAdmin,
+      createdAt: result.createdAt
     });
   });
 
@@ -60,7 +61,15 @@ describe('createUser unit test - 회원가입 관련 서비스 유닛 테스트'
 
     const result = await createUser(em, input);
 
-    expect(result.isAdmin).toBe(true);
+    expect(result).toEqual({
+      id: result.id,
+      username: input.username,
+      name: input.name,
+      email: input.email,
+      phone: input.phone,
+      isAdmin: input.isAdmin,
+      createdAt: result.createdAt
+    });
   });
 
   it('isAdmin이 없는 user 저장 성공', async () => {
@@ -74,7 +83,15 @@ describe('createUser unit test - 회원가입 관련 서비스 유닛 테스트'
 
     const result = await createUser(em, input);
 
-    expect(result.isAdmin).toBe(false);
+    expect(result).toEqual({
+      id: result.id,
+      username: input.username,
+      name: input.name,
+      email: input.email,
+      phone: input.phone,
+      isAdmin: false,
+      createdAt: result.createdAt
+    });
   });
 
   it('phone이 없는 user 저장 성공', async () => {
@@ -87,7 +104,15 @@ describe('createUser unit test - 회원가입 관련 서비스 유닛 테스트'
 
     const result = await createUser(em, input);
 
-    expect(result.phone).toBe(undefined);
+    expect(result).toEqual({
+      id: result.id,
+      username: input.username,
+      name: input.name,
+      email: input.email,
+      phone: null,
+      isAdmin: false,
+      createdAt: result.createdAt
+    });
   });
 
   it('username 중복 시 에러 발생', async () => {


### PR DESCRIPTION
## DTO 기반으로 응답하도록 변경
### 회원가입 API, M클래스 생성 API 변경
- 기존에 DB에 저장하기 위한 만든 객체로 응답하고 있던 것을 DTO로 응답하도록 변경
- 서비스 함수(createUser, createMClass) 변경
  - 그에 따른 컨트롤러 변경
- undefined인 필드는 null로 응답