### PR TITLE
회원가입 API에서는 일반 사용자만 가입 가능하도록 변경

### DIFF
--- a/src/dtos/CreateUserDto.ts
+++ b/src/dtos/CreateUserDto.ts
@@ -25,8 +25,4 @@ export class CreateUserDto {
   @IsOptional()
   @Matches(/^010-\d{4}-\d{4}$/, { message: ErrorMessages.INVALID_PHONE })
   phone?: string;
-
-  @IsOptional()
-  @IsBoolean({ message: ErrorMessages.BOOLEAN })
-  isAdmin?: boolean;
 }

--- a/src/dtos/CreateUserResponseDto.ts
+++ b/src/dtos/CreateUserResponseDto.ts
@@ -16,10 +16,7 @@ export class CreateUserResponseDto {
     @Expose()
     @Transform(({ value }) => value ?? null)
     phone: string | null;
-
-    @Expose()
-    isAdmin: boolean;
-
+    
     @Expose()
     createdAt: Date;
 }

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -20,7 +20,6 @@ export async function createUser(em: EntityManager, data: CreateUserDto) {
   user.name = data.name;
   user.email = data.email;
   user.phone = data.phone;
-  user.isAdmin = data.isAdmin ?? false;
 
   repo.create(user);
   await em.flush();

--- a/src/tests/integration/mclass-id-apply.test.ts
+++ b/src/tests/integration/mclass-id-apply.test.ts
@@ -3,8 +3,9 @@ import request from 'supertest';
 import { DI, start } from '../../index';
 import app from '../../app';
 import { ErrorMessages } from '../../constants';
+import { getBearerToken } from '../utils';
 
-describe('M클래스 생성 API POST /api/mclasses 통합 테스트', () => {
+describe('M클래스 신청 API POST /api/mclasses/:id/apply 통합 테스트', () => {
   let adminToken: string;
 
   const getApi = (id: number) => `/api/mclasses/${id}/apply`;
@@ -12,19 +13,11 @@ describe('M클래스 생성 API POST /api/mclasses 통합 테스트', () => {
   beforeAll(async () => {
     await start;
     await DI.orm.getSchemaGenerator().refreshDatabase();
+    DI.em = DI.orm.em.fork();
 
-    // 회원가입 및 로그인하여 토큰 획득
-    const adminUserData = {
-        username: 'admin',
-        password: 'password',
-        name: 'admin',
-        email: 'admin@example.com',
-        isAdmin: true
-    };
-    await request(app).post('/api/users/signup').send(adminUserData);
-    const LoginResult = await request(app).post('/api/users/login').send(adminUserData);
-
-    adminToken = `Bearer ${LoginResult.body.accessToken}`;
+    // 관리자 토큰 획득
+    DI.em = DI.orm.em.fork();
+    adminToken = await getBearerToken(DI.em);
   });
 
   afterAll(async () => {

--- a/src/tests/integration/mclasses-id-delete.test.ts
+++ b/src/tests/integration/mclasses-id-delete.test.ts
@@ -3,6 +3,7 @@ import request from 'supertest';
 import { DI, start } from '../../index';
 import app from '../../app';
 import { ErrorMessages } from '../../constants';
+import { getBearerToken } from '../utils';
 
 const API = '/api/mclasses/';
 
@@ -12,19 +13,10 @@ describe('M클래스 삭제 API DELETE /api/mclasses/:id 통합 테스트', () =
   beforeAll(async () => {
     await start;
     await DI.orm.getSchemaGenerator().refreshDatabase();
-
-    // 회원가입 및 로그인하여 토큰 획득
-    const adminUserData = {
-        username: 'admin',
-        password: 'password',
-        name: 'admin',
-        email: 'admin@example.com',
-        isAdmin: true
-    };
-    await request(app).post('/api/users/signup').send(adminUserData);
-    const LoginResult = await request(app).post('/api/users/login').send(adminUserData);
-
-    adminToken = `Bearer ${LoginResult.body.accessToken}`;
+    
+    // 관리자 토큰 획득
+    DI.em = DI.orm.em.fork();
+    adminToken = await getBearerToken(DI.em);
   });
 
   afterAll(async () => {

--- a/src/tests/integration/mclasses-id-get.test.ts
+++ b/src/tests/integration/mclasses-id-get.test.ts
@@ -3,6 +3,7 @@ import request from 'supertest';
 import { DI, start } from '../../index';
 import app from '../../app';
 import { ErrorMessages } from '../../constants';
+import { getBearerToken } from '../utils';
 
 const API = '/api/mclasses/';
 
@@ -24,18 +25,9 @@ describe('M클래스 상세 조회 API GET /api/mclasses/:id 통합 테스트', 
     await start;
     await DI.orm.getSchemaGenerator().refreshDatabase();
 
-    // 1. 회원가입 및 로그인하여 토큰 획득
-    const adminUserData = {
-      username: 'admin',
-      password: 'password',
-      name: 'admin',
-      email: 'admin@example.com',
-      isAdmin: true
-    };
-    await request(app).post('/api/users/signup').send(adminUserData);
-    const LoginResult = await request(app).post('/api/users/login').send(adminUserData);
-
-    adminToken = `Bearer ${LoginResult.body.accessToken}`;
+    // 1. 관리자 토큰 획득
+    DI.em = DI.orm.em.fork();
+    adminToken = await getBearerToken(DI.em);
 
     // 2. M클래스 생성
     const mclass = await request(app).post(API).set('Authorization', adminToken).send(mclassData);

--- a/src/tests/integration/mclasses-post.test.ts
+++ b/src/tests/integration/mclasses-post.test.ts
@@ -3,31 +3,20 @@ import request from 'supertest';
 import { DI, start } from '../../index';
 import app from '../../app';
 import { ErrorMessages } from '../../constants';
+import { getBearerToken } from '../utils';
 
 const API = '/api/mclasses';
 
 describe('M클래스 생성 API POST /api/mclasses 통합 테스트', () => {
-  let requestUserId: number;
   let adminToken: string;
-
-  const adminUserData = {
-    username: 'admin',
-    password: 'password',
-    name: 'admin',
-    email: 'admin@example.com',
-    isAdmin: true
-  };
 
   beforeAll(async () => {
     await start;
     await DI.orm.getSchemaGenerator().refreshDatabase();
 
-    // 회원가입 및 로그인하여 토큰 획득
-    const signupResult = await request(app).post('/api/users/signup').send(adminUserData);
-    const LoginResult = await request(app).post('/api/users/login').send(adminUserData);
-
-    requestUserId = signupResult.body.id;
-    adminToken = `Bearer ${LoginResult.body.accessToken}`;
+    // 관리자 토큰 획득
+    DI.em = DI.orm.em.fork();
+    adminToken = await getBearerToken(DI.em);
   });
 
   afterAll(async () => {

--- a/src/tests/integration/signup.test.ts
+++ b/src/tests/integration/signup.test.ts
@@ -25,14 +25,13 @@ describe('회원가입 API POST /api/usres/signup 통합 테스트', () => {
     await DI.em.nativeDelete(User, {})
   });
 
-  it('일반 유저 회원가입 성공', async () => {
+  it('회원가입 성공', async () => {
     const input = {
       username: 'test',
       password: 'password',
       name: 'user',
       email: 'test@example.com',
       phone: '010-1234-5678',
-      isAdmin: false
     };
 
     const result = await request(app).post(API).send(input);
@@ -44,7 +43,6 @@ describe('회원가입 API POST /api/usres/signup 통합 테스트', () => {
       name: input.name,
       email: input.email,
       phone: input.phone,
-      isAdmin: input.isAdmin,
       createdAt: result.body.createdAt
     });
 
@@ -52,53 +50,9 @@ describe('회원가입 API POST /api/usres/signup 통합 테스트', () => {
     const user = await DI.em.findOneOrFail(User, { username: input.username });
     const isEqual = await bcrypt.compare(input.password, user.password);
     expect(isEqual).toBe(true);
-  });
 
-  it('관리자 유저 회원가입 성공', async () => {
-    const input = {
-      username: 'test',
-      password: 'password',
-      name: 'user',
-      email: 'test@example.com',
-      phone: '010-1234-5678',
-      isAdmin: true
-    };
-
-    const result = await request(app).post(API).send(input);
-
-    expect(result.status).toBe(201);
-    expect(result.body).toEqual({
-      id: result.body.id,
-      username: input.username,
-      name: input.name,
-      email: input.email,
-      phone: input.phone,
-      isAdmin: input.isAdmin,
-      createdAt: result.body.createdAt
-    });
-  })
-
-  it('isAdmin이 주어지지 않은 경우 일반 유저로 가입 성공', async () => {
-    const input = {
-      username: 'test',
-      password: 'password',
-      name: 'user',
-      email: 'test@example.com',
-      phone: '010-1234-5678'
-    };
-
-    const result = await request(app).post(API).send(input);
-
-    expect(result.status).toBe(201);
-    expect(result.body).toEqual({
-      id: result.body.id,
-      username: input.username,
-      name: input.name,
-      email: input.email,
-      phone: input.phone,
-      isAdmin: false,
-      createdAt: result.body.createdAt
-    });
+    // 관리자 여부가 false로 저장되었는지 확인
+    expect(user.isAdmin).toBe(false);
   });
 
   it('phone이 주어지지 않은 경우 가입 성공', async () => {
@@ -118,7 +72,6 @@ describe('회원가입 API POST /api/usres/signup 통합 테스트', () => {
       name: input.name,
       email: input.email,
       phone: null,
-      isAdmin: false,
       createdAt: result.body.createdAt
     });
   });

--- a/src/tests/unit/userService.test.ts
+++ b/src/tests/unit/userService.test.ts
@@ -30,7 +30,6 @@ describe('createUser unit test - 회원가입 관련 서비스 유닛 테스트'
       name: 'user',
       email: 'test@example.com',
       phone: '010-1234-5678',
-      isAdmin: false,
     };
 
     const hashedPassword = 'hashedpassword';
@@ -44,52 +43,6 @@ describe('createUser unit test - 회원가입 관련 서비스 유닛 테스트'
       name: input.name,
       email: input.email,
       phone: input.phone,
-      isAdmin: input.isAdmin,
-      createdAt: result.createdAt
-    });
-  });
-
-  it('isAdmin이 true인 유저 저장 성공', async () => {
-    const input = {
-      username: 'test',
-      password: 'password',
-      name: 'user',
-      email: 'test@example.com',
-      phone: '010-1234-5678',
-      isAdmin: true,
-    };
-
-    const result = await createUser(em, input);
-
-    expect(result).toEqual({
-      id: result.id,
-      username: input.username,
-      name: input.name,
-      email: input.email,
-      phone: input.phone,
-      isAdmin: input.isAdmin,
-      createdAt: result.createdAt
-    });
-  });
-
-  it('isAdmin이 없는 user 저장 성공', async () => {
-    const input = {
-      username: 'test',
-      password: 'password',
-      name: 'user',
-      email: 'test@example.com',
-      phone: '010-1234-5678'
-    };
-
-    const result = await createUser(em, input);
-
-    expect(result).toEqual({
-      id: result.id,
-      username: input.username,
-      name: input.name,
-      email: input.email,
-      phone: input.phone,
-      isAdmin: false,
       createdAt: result.createdAt
     });
   });
@@ -110,7 +63,6 @@ describe('createUser unit test - 회원가입 관련 서비스 유닛 테스트'
       name: input.name,
       email: input.email,
       phone: null,
-      isAdmin: false,
       createdAt: result.createdAt
     });
   });

--- a/src/tests/utils.ts
+++ b/src/tests/utils.ts
@@ -1,0 +1,24 @@
+import request from 'supertest';
+import { EntityManager } from '@mikro-orm/postgresql';
+import bcrypt from 'bcrypt';
+
+import app from '../app';
+import { User } from '../entities';
+
+export async function getBearerToken(em: EntityManager, isAdmin: boolean = true) {
+  // 관리자 유저 저장
+  const adminUser = new User();
+  adminUser.username = 'admin';
+  adminUser.password = await bcrypt.hash('password', 10);;
+  adminUser.name = 'admin';
+  adminUser.email = 'admin@example.com';
+  adminUser.isAdmin = isAdmin;
+  
+  const userRepo = em.getRepository(User);
+  userRepo.create(adminUser);
+  await em.flush();
+  
+  // 로그인 하여 토큰 획득
+  const LoginResult = await request(app).post('/api/users/login').send({ username: adminUser.username, password: 'password' });
+  return `Bearer ${LoginResult.body.accessToken}`;
+}


### PR DESCRIPTION
## 회원가입 API 변경
### 일반 사용자만 가입 가능하도록 변경
* 기존 회원가입 API에서 request body에 isAdmin: true를 주어 관리자로도 가입할 수 있던 것에서 일반 사용자만 가입 가능하도록 변경
* request body, response body에서 isAdmin 제거

## 테스트 코드 유틸 함수 생성 및 적용
### getBearerToken 함수 생성 및 적용
* 기존에 테스트 코드에서 관리자 토큰을 얻기 위해 회원가입 API를 사용하던 것이 API 변경으로 불가능해져 생성
* user 데이터 저장하고 로그인 API 호출하여 Bearer 토큰 리턴