### PR TITLE
M클래스 신청 API에서 본인이 생성한 M클래스인 경우 신청 불가하도록 변경

### DIFF
--- a/src/constants/error-messages.ts
+++ b/src/constants/error-messages.ts
@@ -33,6 +33,7 @@ export const ErrorMessages = {
   MAX_PEOPLE_EXCESS: '정원 초과',
   ALREADY_APPLY: '이미 신청한 클래스입니다.',
   MCLASS_HAS_APPLICATION: '신청자가 있는 클래스입니다.',
+  CAN_NOT_APPLY_TO_OWN_MCLASS: '본인이 만든 M클래스는 신청할 수 없습니다.',
 
   LOGIN_FAILED: '로그인 실패',
 

--- a/src/tests/integration/mclasses-id-delete.test.ts
+++ b/src/tests/integration/mclasses-id-delete.test.ts
@@ -119,8 +119,11 @@ describe('M클래스 삭제 API DELETE /api/mclasses/:id 통합 테스트', () =
     const createResult = await request(app).post(API).set('Authorization', adminToken).send(mclassData);
     const mclassId = createResult.body.id;
 
+    // 다른 사용자 토큰 획득
+    const token = await getBearerToken(DI.em, false);
+
     // M클래스 신청
-    await request(app).post(`${API}${mclassId}/apply`).set('Authorization', adminToken);
+    await request(app).post(`${API}${mclassId}/apply`).set('Authorization', token);
 
     const result = await request(app).delete(API + mclassId).set('Authorization', adminToken);
 

--- a/src/tests/integration/users-applications.test.ts
+++ b/src/tests/integration/users-applications.test.ts
@@ -8,7 +8,7 @@ import { getBearerToken } from "../utils";
 const API = '/api/users/applications';
 
 describe('내 신청 내역 조회 API GET /api/users/applications 통합 테스트', () => {
-  let adminToken: string;
+  let userToken: string;
 
   const applicationCount = 15;
   const mclassData = {
@@ -27,14 +27,17 @@ describe('내 신청 내역 조회 API GET /api/users/applications 통합 테스
 
     // 1. 관리자 토큰 획득
     DI.em = DI.orm.em.fork();
-    adminToken = await getBearerToken(DI.em);
+    const adminToken = await getBearerToken(DI.em);
 
-    // 2. M클래스 applicationCount 개 생성
+    // 2. 다른 사용자 토큰 획득
+    userToken = await getBearerToken(DI.em, false);
+
+    // 3. M클래스 applicationCount 개 생성
     for (let i = 0; i < applicationCount; i++) {
       const mclass = await request(app).post('/api/mclasses').set('Authorization', adminToken).send(mclassData);
   
-      // 3. 생성한 M클래스 신청
-      await request(app).post(`/api/mclasses/${mclass.body.id}/apply`).set('Authorization', adminToken);
+      // 4. 생성한 M클래스 신청
+      await request(app).post(`/api/mclasses/${mclass.body.id}/apply`).set('Authorization', userToken);
     }
   });
 
@@ -52,7 +55,7 @@ describe('내 신청 내역 조회 API GET /api/users/applications 통합 테스
       limit: 5,
       last: 10
     };
-    const result = await request(app).get(API).query(input).set('Authorization', adminToken)
+    const result = await request(app).get(API).query(input).set('Authorization', userToken)
 
     expect(result.status).toBe(200);
     expect(result.body.list).toBeInstanceOf(Array);
@@ -74,7 +77,7 @@ describe('내 신청 내역 조회 API GET /api/users/applications 통합 테스
       last: 15
     };
     
-    const result = await request(app).get(API).query(input).set('Authorization', adminToken);
+    const result = await request(app).get(API).query(input).set('Authorization', userToken);
 
     expect(result.status).toBe(200);
     expect(result.body.list).toBeInstanceOf(Array);
@@ -95,7 +98,7 @@ describe('내 신청 내역 조회 API GET /api/users/applications 통합 테스
       limit: 5,
       last: undefined
     };
-    const result = await request(app).get(API).query(input).set('Authorization', adminToken)
+    const result = await request(app).get(API).query(input).set('Authorization', userToken)
 
     expect(result.status).toBe(200);
     expect(result.body.list).toBeInstanceOf(Array);

--- a/src/tests/unit/mclassService.test.ts
+++ b/src/tests/unit/mclassService.test.ts
@@ -3,7 +3,7 @@ import { QueryOrder } from '@mikro-orm/postgresql';
 import { createMClass, getMClassList, getMClassById, deleteMClassById, applyToMClass } from '../../services/mclassService';
 import { MClass } from '../../entities';
 import { ErrorMessages } from '../../constants';
-import { ConflictError, NotFoundError, ValidationError } from '../../errors';
+import { ConflictError, ForbiddenError, NotFoundError, ValidationError } from '../../errors';
 
 describe('createMClass unit test - M클래스 생성 관련 서비스 유닛 테스트', () => {
   let em: any;
@@ -277,7 +277,11 @@ describe('applyToMClass unit test - M클래스 신청 관련 서비스 유닛 �
   });
 
   it('application 저장 성공', async () => {
-    em.findOne.mockResolvedValue({ id: 1, maxPeople: 10 });
+    em.findOne.mockResolvedValue({
+      id: 1,
+      maxPeople: 10,
+      createdUser: { id: 2 }
+    });
     appRepo.count.mockResolvedValue(0);
     appRepo.findOne.mockResolvedValue(null);
 
@@ -296,8 +300,22 @@ describe('applyToMClass unit test - M클래스 신청 관련 서비스 유닛 �
     expect(em.rollback).toHaveBeenCalled();
   });
 
+  it('본인이 만든 mclass인 경우 실패', async () => {
+    em.findOne.mockResolvedValue({ createdUser: requestUser })
+
+    await expect(applyToMClass(em, 1, requestUser)).rejects.toThrow(new ForbiddenError(ErrorMessages.CAN_NOT_APPLY_TO_OWN_MCLASS));
+    expect(em.begin).toHaveBeenCalled();
+    expect(em.commit).not.toHaveBeenCalled();
+    expect(em.rollback).toHaveBeenCalled();
+  });
+
   it('deadline이 현재 시간 이하인 경우 실패', async () => {
-    em.findOne.mockResolvedValue({ id: 1, maxPeople: 10, deadline: new Date(Date.now() - 1000) });
+    em.findOne.mockResolvedValue({
+      id: 1,
+      maxPeople: 10,
+      deadline: new Date(Date.now() - 1000),
+      createdUser: { id: 2 }
+    });
     appRepo.count.mockResolvedValue(0);
     appRepo.findOne.mockResolvedValue(null);
 
@@ -308,7 +326,11 @@ describe('applyToMClass unit test - M클래스 신청 관련 서비스 유닛 �
   });
 
   it('application 수가 maxPeople 이상인 경우 실패', async () => {
-    em.findOne.mockResolvedValue({ id: 1, maxPeople: 10 });
+    em.findOne.mockResolvedValue({
+      id: 1,
+      maxPeople: 10,
+      createdUser: { id: 2 }
+    });
     appRepo.count.mockResolvedValue(100);
     appRepo.findOne.mockResolvedValue(null);
 
@@ -319,7 +341,11 @@ describe('applyToMClass unit test - M클래스 신청 관련 서비스 유닛 �
   });
 
   it('해당 mclass와 user에 해당하는 application이 이미 존재한 경우 실패', async () => {
-    em.findOne.mockResolvedValue({ id: 1, maxPeople: 10 });
+    em.findOne.mockResolvedValue({
+      id: 1,
+      maxPeople: 10,
+      createdUser: { id: 2 }
+    });
     appRepo.count.mockResolvedValue(0);
     appRepo.findOne.mockResolvedValue({ id: 1 });
 

--- a/src/tests/utils.ts
+++ b/src/tests/utils.ts
@@ -6,19 +6,21 @@ import app from '../app';
 import { User } from '../entities';
 
 export async function getBearerToken(em: EntityManager, isAdmin: boolean = true) {
-  // 관리자 유저 저장
-  const adminUser = new User();
-  adminUser.username = 'admin';
-  adminUser.password = await bcrypt.hash('password', 10);;
-  adminUser.name = 'admin';
-  adminUser.email = 'admin@example.com';
-  adminUser.isAdmin = isAdmin;
+  const rand = Math.random().toString().substring(0, 8);
+
+  // 유저 저장
+  const user = new User();
+  user.username = rand;
+  user.password = await bcrypt.hash('password', 10);;
+  user.name = rand;
+  user.email = `${rand}@example.com`;
+  user.isAdmin = isAdmin;
   
   const userRepo = em.getRepository(User);
-  userRepo.create(adminUser);
+  userRepo.create(user);
   await em.flush();
   
   // 로그인 하여 토큰 획득
-  const LoginResult = await request(app).post('/api/users/login').send({ username: adminUser.username, password: 'password' });
+  const LoginResult = await request(app).post('/api/users/login').send({ username: user.username, password: 'password' });
   return `Bearer ${LoginResult.body.accessToken}`;
 }


### PR DESCRIPTION
## M클래스 신청 API 변경
### 본인이 생성한 M클래스인 경우 신청 불가하도록 변경
* 기존에 본인이 생성한 M클래스도 신청 가능하던 것에서 본인이 만든 M클래스의 경우 신청 불가능 하도록 변경

## 테스트 코드 수정
### 테스트 케이스 추가 및 수정
* 본인이 생성한 M클래스 신청 불가능 테스트 케이스 추가
* 본인이 생성한 M클래스 신청 불가능 조건에 영향을 받는 테스트 케이스 수정 (ex. 내 신청 내역 조회)

### 테스트 유틸 함수 수정
* getBearerToken 함수에서 기존에 항상 같은 정보로 user를 생성하던 것을 랜덤한 정보로 생성하도록 변경