### PR TITLE
Refresh Token 발급 및 토큰 유효 기간 설정

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,9 @@ dbPort=5432
 
 # JWT 설정
 jwtSecretKey=your_jwt_secret_key
+jwtExpiresIn=your_jwt_expires_in
+jwtRefreshSecretKey=your_refresh_jwt_key
+jwtRefreshtExpiresIn=your_jwt_refresh_expires_in
+
+# 쿠키 설정
+cookieMaxAge=your_cookie_max_age

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -13,6 +13,12 @@ export const ENV = {
     PORT: Number(process.env.dbPort),
   },
   JWT: {
-    SECRET_KEY: process.env.jwtSecretKey as string
+    SECRET_KEY: process.env.jwtSecretKey as string,
+    EXPIRES_IN: process.env.jwtExpiresIn,
+    REFRESH_SECRET_KEY: process.env.jwtRefreshSecretKey as string,
+    REFRESH_EXPIRES_IN: process.env.jwtRefreshtExpiresIn
+  },
+  COOKIE: {
+    MAX_AGE: Number(process.env.cookieMaxAge)  * 24 * 60 * 60 * 1000
   }
 };

--- a/src/constants/error-messages.ts
+++ b/src/constants/error-messages.ts
@@ -36,7 +36,7 @@ export const ErrorMessages = {
   CAN_NOT_APPLY_TO_OWN_MCLASS: '본인이 만든 M클래스는 신청할 수 없습니다.',
 
   LOGIN_FAILED: '로그인 실패',
-
+  ACCESS_TOKEN_EXPIRED: '액세스 토큰 만료',
   UNAUTHORIZED: '인증 실패',
   FORBIDDEN: '권한이 없습니다.',
   NOT_FOUND: '존재하지 않습니다.',

--- a/src/entities/User.ts
+++ b/src/entities/User.ts
@@ -21,4 +21,7 @@ export class User extends BaseEntity{
 
   @Property()
   isAdmin: boolean = false;
+
+  @Property({ nullable: true, length: 255 })
+  refreshToken?: string;
 }

--- a/src/middlewares/authenticate.ts
+++ b/src/middlewares/authenticate.ts
@@ -3,6 +3,7 @@ import jwt from 'jsonwebtoken';
 
 import { ENV } from '../config';
 import { UnauthorizedError } from '../errors';
+import { ErrorMessages } from '../constants';
 
 export const verifyJwt = (req: Request, res: Response, next: NextFunction) => {
   const auth = req.headers.authorization;
@@ -20,7 +21,11 @@ export const verifyJwt = (req: Request, res: Response, next: NextFunction) => {
     };
     
     return next();
-  } catch (err: any) {
+  }
+  catch (err: any) {
+    if (err.name === 'TokenExpiredError') {
+      return next(new UnauthorizedError(ErrorMessages.ACCESS_TOKEN_EXPIRED));
+    }
     return next(new UnauthorizedError());
   }
 };

--- a/src/tests/integration/login.test.ts
+++ b/src/tests/integration/login.test.ts
@@ -36,6 +36,9 @@ describe('로그인 API POST /api/users/login 통합 테스트', () => {
 
     expect(result.status).toBe(201);
     expect(result.body).toEqual({ accessToken: expect.any(String) });
+
+    const cookies = result.headers['set-cookie'] as any;
+    expect(cookies.some((cookie: string) => cookie.startsWith('refreshToken='))).toBe(true);
   });
 
   it('존재하지 않는 아이디로 로그인 시 실패', async () => {

--- a/src/tests/integration/users-applications.test.ts
+++ b/src/tests/integration/users-applications.test.ts
@@ -3,7 +3,7 @@ import request from "supertest";
 import { DI, start } from '../../index';
 import app from '../../app';
 import { DefaultLimits, ErrorMessages } from "../../constants";
-import { getBearerToken } from "../utils";
+import { getBearerToken, getExpiredBearerToken } from "../utils";
 
 const API = '/api/users/applications';
 
@@ -124,4 +124,18 @@ describe('내 신청 내역 조회 API GET /api/users/applications 통합 테스
     expect(result.status).toBe(401);
     expect(result.body.message).toBe(ErrorMessages.UNAUTHORIZED);
   })
+
+  it('JWT이 만료된 경우 경우 실패', async () => {
+    const input = {
+      limit: 5,
+      last: 10
+    };
+
+    const expiredToken = await getExpiredBearerToken(DI.em);
+
+    const result = await request(app).get(API).query(input).set('Authorization', expiredToken);
+
+    expect(result.status).toBe(401);
+    expect(result.body.message).toBe(ErrorMessages.ACCESS_TOKEN_EXPIRED);
+  });
 });

--- a/src/tests/unit/userService.test.ts
+++ b/src/tests/unit/userService.test.ts
@@ -115,7 +115,10 @@ describe('loginUser unit test - 로그인 관련 서비스 유닛 테스트', ()
 
   beforeEach(() => {
     userRepo = { findOne: jest.fn() }
-    em = { getRepository: jest.fn(() => userRepo) }
+    em = {
+      getRepository: jest.fn(() => userRepo),
+      flush: jest.fn()
+    }
   });
 
   it('JWT 토큰 발급 성공', async () => {
@@ -136,7 +139,7 @@ describe('loginUser unit test - 로그인 관련 서비스 유닛 테스트', ()
 
     const result = await loginUser(em, input);
 
-    expect(result).toBe(mockToken);
+    expect(result).toEqual({ accessToken: mockToken, refreshToken: mockToken });
   });
 
   it('존재하지 않는 username 사용 시 에러', async () => {

--- a/src/tests/utils.ts
+++ b/src/tests/utils.ts
@@ -1,9 +1,11 @@
 import request from 'supertest';
 import { EntityManager } from '@mikro-orm/postgresql';
 import bcrypt from 'bcrypt';
+import jwt from 'jsonwebtoken';
 
 import app from '../app';
 import { User } from '../entities';
+import { ENV } from '../config';
 
 export async function getBearerToken(em: EntityManager, isAdmin: boolean = true) {
   const rand = Math.random().toString().substring(0, 8);
@@ -23,4 +25,31 @@ export async function getBearerToken(em: EntityManager, isAdmin: boolean = true)
   // 로그인 하여 토큰 획득
   const LoginResult = await request(app).post('/api/users/login').send({ username: user.username, password: 'password' });
   return `Bearer ${LoginResult.body.accessToken}`;
+}
+
+export async function getExpiredBearerToken(em: EntityManager, isAdmin: boolean = true) {
+  const rand = Math.random().toString().substring(0, 8);
+
+  const user = new User();
+  user.username = rand;
+  user.password = await bcrypt.hash('password', 10);;
+  user.name = rand;
+  user.email = `${rand}@example.com`;
+  user.isAdmin = isAdmin;
+
+  const userRepo = em.getRepository(User);
+  userRepo.create(user);
+  await em.flush();
+
+  const accessToken = jwt.sign(
+    {
+      id: user.id,
+      username: user.username,
+      isAdmin: user.isAdmin
+    },
+    ENV.JWT.SECRET_KEY,
+    { expiresIn: 0}
+  );
+
+  return `Bearer ${accessToken}`;
 }


### PR DESCRIPTION
## Refresh Token 발급 및 토큰 유효 기간 설정
* 로그인 서비스 코드에서 refresh token 생성 코드 추가
* 토큰 발급 시에 유효 기간 설정
* 로그인 API에서 응답할 때 쿠키에 refresh token 추가
* 환경 변수 값에 유효 기간, 솔트 등 정보 추가 (.env.example 참고)