### PR TITLE
M클래스 생성 시 날짜에 대한 유효성 검증 Custom validator로 하도록 변경

### DIFF
--- a/src/constants/error-messages.ts
+++ b/src/constants/error-messages.ts
@@ -22,7 +22,9 @@ export const ErrorMessages = {
   INVALID_PHONE: '올바른 휴대폰 번호 형식이 아닙니다.',
   INVALID_DATE: '올바른 날짜 형식이 아닙니다.',
 
-  WRONG_DATE: '유효하지 않은 날짜입니다.',
+  GT_NOW: '현재 시간 이후여야 합니다',
+  INVALID_DEADLINE_START_AT: '마감 시간과 시작일시를 확인해주세요.',
+  INVALID_START_AT_END_AT: '시작일시와 마감일시를 확인해주세요.',
 
   EXSITING_DATA: '존재하는 데이터입니다',
   EXISTING_USERNAME: '중복된 아이디입니다.',

--- a/src/dtos/CreateMClassDto.ts
+++ b/src/dtos/CreateMClassDto.ts
@@ -1,6 +1,7 @@
-import { IsString, Length, IsOptional, IsInt, Min, IsDateString, IsNotEmpty } from 'class-validator';
+import { IsString, Length, IsOptional, IsInt, Min, IsDateString, IsNotEmpty, Validate } from 'class-validator';
 
 import { ErrorMessages } from '../constants';
+import { MClassDateValidator, DeadlineStartAtDateValidator, StartAtEndAtDateValidator } from '../validators';
 
 export class CreateMClassDto {
   @IsString({ message: ErrorMessages.STRING })
@@ -17,12 +18,19 @@ export class CreateMClassDto {
   @Min(1, { message: ErrorMessages.MAX_PEOPLE_MINIMUM })
   maxPeople: number;
 
+  @Validate(DeadlineStartAtDateValidator)
+  @Validate(MClassDateValidator)
   @IsDateString({}, { message: ErrorMessages.INVALID_DATE })
   deadline: string;
 
+  @Validate(StartAtEndAtDateValidator)
+  @Validate(DeadlineStartAtDateValidator)
+  @Validate(MClassDateValidator)
   @IsDateString({}, { message: ErrorMessages.INVALID_DATE })
   startAt: string;
 
+  @Validate(StartAtEndAtDateValidator)
+  @Validate(MClassDateValidator)
   @IsDateString({}, { message: ErrorMessages.INVALID_DATE })
   endAt: string;
 

--- a/src/dtos/CreateUserDto.ts
+++ b/src/dtos/CreateUserDto.ts
@@ -1,4 +1,4 @@
-import { IsEmail, IsOptional, IsString, IsBoolean, Length, Matches, IsNotEmpty } from 'class-validator';
+import { IsEmail, IsOptional, IsString, Length, Matches, IsNotEmpty } from 'class-validator';
 
 import { ErrorMessages } from '../constants';
 

--- a/src/services/mclassService.ts
+++ b/src/services/mclassService.ts
@@ -4,14 +4,9 @@ import { plainToInstance } from 'class-transformer';
 import { CreateMClassDto, UserPayload, MClassListItemDto, GetListQueryDto, MClassDetailDto, CreateMClassResponseDto } from '../dtos';
 import { User, MClass, Application } from '../entities';
 import { ErrorMessages } from '../constants';
-import { ValidationError, NotFoundError, ConflictError, ForbiddenError } from '../errors';
+import { NotFoundError, ConflictError, ForbiddenError } from '../errors';
 
 export async function createMClass(em: EntityManager, data: CreateMClassDto, requestUser: UserPayload) {
-  const deadline = new Date(data.deadline);
-  const startAt = new Date(data.startAt);
-  const endAt = new Date(data.endAt);
-  validateDate(deadline, startAt, endAt);
-
   const userRef = em.getReference(User, requestUser.id);
 
   const repo = em.getRepository(MClass);
@@ -20,9 +15,9 @@ export async function createMClass(em: EntityManager, data: CreateMClassDto, req
   mclass.title = data.title;
   mclass.description = data.description;
   mclass.maxPeople = data.maxPeople;
-  mclass.deadline = deadline;
-  mclass.startAt = startAt;
-  mclass.endAt = endAt;
+  mclass.deadline = new Date(data.deadline);
+  mclass.startAt = new Date(data.startAt);
+  mclass.endAt = new Date(data.endAt);
   mclass.fee = data.fee;
   mclass.createdUser = userRef;
 
@@ -131,23 +126,5 @@ async function assertApplication(appRepo: EntityRepository<Application>, mclass:
   const currentCount = await appRepo.count({ mclass: mclass });
   if (currentCount >= mclass.maxPeople) {
     throw new ConflictError(ErrorMessages.MAX_PEOPLE_EXCESS);
-  }
-}
-
-function validateDate(deadline: Date, startAt: Date, endAt: Date) {
-  const now = new Date();
-  // 마감 시간 및 시작 시간은 현재 시간보다 커야 함
-  if (deadline <= now || startAt <= now) {
-    throw new ValidationError(ErrorMessages.WRONG_DATE);
-  }
-
-  // 시작일시는 마감 시간보다 커야 함
-  if (startAt <= deadline) {
-    throw new ValidationError(ErrorMessages.WRONG_DATE);
-  }
-
-  // 종료일시는 시작일시보다 커야 함
-  if (endAt <= startAt) {
-    throw new ValidationError(ErrorMessages.WRONG_DATE);
   }
 }

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -58,7 +58,7 @@ export async function loginUser(em: EntityManager, data: LoginDto) {
 
   // refresh token db에 저장
   user.refreshToken = refreshToken;
-  await em.flush()
+  await em.flush();
 
   return { accessToken, refreshToken };
 }

--- a/src/tests/integration/mclasses-post.test.ts
+++ b/src/tests/integration/mclasses-post.test.ts
@@ -143,4 +143,55 @@ describe('M클래스 생성 API POST /api/mclasses 통합 테스트', () => {
     expect(result.status).toBe(400);
     expect(result.body.message).toBe(ErrorMessages.VALIDATION_FAILED);
   });
+
+  it('deadline이 현재 시간보다 작을 경우 실패', async () => {
+    const input = {
+      title: 'test class',
+      description: 'class description',
+      maxPeople: 10,
+      deadline: new Date(Date.now() - 1000 * 60).toISOString(),
+      startAt: new Date(Date.now() + 1000 * 60 * 60).toISOString(),
+      endAt: new Date(Date.now() + 1000 * 60 * 60 * 2).toISOString(),
+      fee: 100
+    };
+
+    const result = await request(app).post(API).set('Authorization', adminToken).send(input)
+
+    expect(result.status).toBe(400);
+    expect(result.body.message).toBe(ErrorMessages.VALIDATION_FAILED);
+  });
+
+  it('startAt이 deadlin보다 작을 경우 실패', async () => {
+    const input = {
+      title: 'test class',
+      description: 'class description',
+      maxPeople: 10,
+      deadline: new Date(Date.now() + 1000 * 60 * 60).toISOString(),
+      startAt: new Date(Date.now() + 1000 * 60).toISOString(),
+      endAt: new Date(Date.now() + 1000 * 60 * 60 * 2).toISOString(),
+      fee: 100
+    };
+
+    const result = await request(app).post(API).set('Authorization', adminToken).send(input)
+
+    expect(result.status).toBe(400);
+    expect(result.body.message).toBe(ErrorMessages.VALIDATION_FAILED);
+  });
+
+  it('endAt이 startAt보다 작을 경우 실패', async () => {
+    const input = {
+      title: 'test class',
+      description: 'class description',
+      maxPeople: 10,
+      deadline: new Date(Date.now() - 1000 * 60).toISOString(),
+      startAt: new Date(Date.now() + 1000 * 60 * 60 * 2).toISOString(),
+      endAt: new Date(Date.now() + 1000 * 60 * 60).toISOString(),
+      fee: 100
+    };
+
+    const result = await request(app).post(API).set('Authorization', adminToken).send(input)
+
+    expect(result.status).toBe(400);
+    expect(result.body.message).toBe(ErrorMessages.VALIDATION_FAILED);
+  });
 });

--- a/src/tests/unit/mclassService.test.ts
+++ b/src/tests/unit/mclassService.test.ts
@@ -74,62 +74,6 @@ describe('createMClass unit test - M클래스 생성 관련 서비스 유닛 테
       createdAt: result.createdAt
     });
   });
-
-  it('deadline이 과거인 경우 실패', async () => {
-    const input = {
-      title: 'test class',
-      description: 'class description',
-      maxPeople: 10,
-      deadline: new Date(Date.now() - 1000 * 60).toISOString(),
-      startAt: new Date(Date.now() + 1000 * 60 * 60).toISOString(),
-      endAt: new Date(Date.now() + 1000 * 60 * 60 * 2).toISOString(),
-      fee: 100
-    };
-
-    await expect(createMClass(em, input, requestUser)).rejects.toThrow(new ValidationError(ErrorMessages.WRONG_DATE));
-  });
-
-  it('startAt이 과거인 경우 실패', async () => {
-    const input = {
-      title: 'test class',
-      description: 'class description',
-      maxPeople: 10,
-      deadline: new Date(Date.now() + 1000 * 60).toISOString(),
-      startAt: new Date(Date.now() - 1000 * 60 * 60).toISOString(),
-      endAt: new Date(Date.now() + 1000 * 60 * 60 * 2).toISOString(),
-      fee: 100
-    };
-
-    await expect(createMClass(em, input, requestUser)).rejects.toThrow(new ValidationError(ErrorMessages.WRONG_DATE));
-  });
-
-  it('startAt이 deadline보다 작은 경우 실패', async () => {
-    const input = {
-      title: 'test class',
-      description: 'class description',
-      maxPeople: 10,
-      deadline: new Date(Date.now() + 1000 * 60 * 60).toISOString(),
-      startAt: new Date(Date.now() + 1000 * 60).toISOString(),
-      endAt: new Date(Date.now() + 1000 * 60 * 60 * 2).toISOString(),
-      fee: 100
-    };
-
-    await expect(createMClass(em, input, requestUser)).rejects.toThrow(new ValidationError(ErrorMessages.WRONG_DATE));
-  });
-
-  it('endAt이 startAt보다 작은 경우 실패', async () => {
-    const input = {
-      title: 'test class',
-      description: 'class description',
-      maxPeople: 10,
-      deadline: new Date(Date.now() + 1000 * 60).toISOString(),
-      startAt: new Date(Date.now() + 1000 * 60 * 60 * 2).toISOString(),
-      endAt: new Date(Date.now() + 1000 * 60 * 60).toISOString(),
-      fee: 100
-    };
-
-    await expect(createMClass(em, input, requestUser)).rejects.toThrow(new ValidationError(ErrorMessages.WRONG_DATE));
-  });
 });
 
 describe('getMClassList unit test - M클래스 목록 조회 관련 서비스 유닛 테스트', () => {

--- a/src/validators/DeadlineStartAtDateValidator.ts
+++ b/src/validators/DeadlineStartAtDateValidator.ts
@@ -1,0 +1,20 @@
+import { ValidationArguments, ValidatorConstraint, ValidatorConstraintInterface } from "class-validator";
+
+import { ErrorMessages } from "../constants";
+
+@ValidatorConstraint({ name: 'isInvalidDeadlineStartAt', async: false })
+export class DeadlineStartAtDateValidator implements ValidatorConstraintInterface {
+  validate(_: any, validationArguments: ValidationArguments): Promise<boolean> | boolean {
+    const dto = validationArguments.object as any;
+    
+    const deadline = new Date(dto.deadline);
+    const startAt = new Date(dto.startAt);
+
+    if (startAt <= deadline) return false;
+
+    return true;
+  }
+  defaultMessage(_: ValidationArguments): string {
+    return ErrorMessages.INVALID_DEADLINE_START_AT;
+  }
+}

--- a/src/validators/MClassDateValidator.ts
+++ b/src/validators/MClassDateValidator.ts
@@ -1,0 +1,18 @@
+import { ValidationArguments, ValidatorConstraint, ValidatorConstraintInterface } from "class-validator";
+
+import { ErrorMessages } from "../constants";
+
+@ValidatorConstraint({ name: 'isInvalidDate', async: false })
+export class MClassDateValidator implements ValidatorConstraintInterface {
+  validate(value: any, _: ValidationArguments): Promise<boolean> | boolean {
+    const now = new Date();
+    const dateValue = new Date(value);
+
+    if (dateValue <= now) return false;
+
+    return true;
+  }
+  defaultMessage(_: ValidationArguments): string {
+    return ErrorMessages.GT_NOW;
+  }
+}

--- a/src/validators/StartAtEndAtDateValidator.ts
+++ b/src/validators/StartAtEndAtDateValidator.ts
@@ -1,0 +1,20 @@
+import { ValidationArguments, ValidatorConstraint, ValidatorConstraintInterface } from "class-validator";
+
+import { ErrorMessages } from "../constants";
+
+@ValidatorConstraint({ name: 'isInvalidStartAtEndAt', async: false })
+export class StartAtEndAtDateValidator implements ValidatorConstraintInterface {
+  validate(_: any, validationArguments: ValidationArguments): Promise<boolean> | boolean {
+    const dto = validationArguments.object as any;
+    
+    const startAt = new Date(dto.startAt);
+    const endAt = new Date(dto.endAt);
+
+    if (endAt <= startAt) return false;
+
+    return true;
+  }
+  defaultMessage(_: ValidationArguments): string {
+    return ErrorMessages.INVALID_START_AT_END_AT;
+  }
+}

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -1,0 +1,3 @@
+export * from './DeadlineStartAtDateValidator';
+export * from './MClassDateValidator';
+export * from './StartAtEndAtDateValidator';


### PR DESCRIPTION
## M클래스 생성 시 날짜에 대한 유효성 검증 Custom validator로 하도록 변경
* 기존에 M클래스 생성 시에 날짜들이 현재 시간보다 큰지 검증하는 등의 로직을 서비스에서 수행하던 것에서 custom validator 이용하도록 변경